### PR TITLE
feat: start.airnote.live redirect (to placeholder)

### DIFF
--- a/start.airnote.live/index.html
+++ b/start.airnote.live/index.html
@@ -1,7 +1,7 @@
 <head>
   <meta
     http-equiv="refresh"
-    content="1; URL=https://via.placeholder.com/728x90.png?text=airnote+quickstart"
+    content="0; URL=https://via.placeholder.com/728x90.png?text=airnote+quickstart"
   />
 </head>
 <body>


### PR DESCRIPTION
# What

https://airtable.com/tbl54NpcGxKHABiyr/viwQeeZNrER3vdbpV/reczgnrU1LKoHJHOU?blocks=hide

http://start.airnote.live should redirect to the airnote quickstart

## Solution

Spin up a render.sh app for start.airnote.live and deploy the `airnote.live/start.airnote.live/` folder to that static site. There is an `index.html` in `airnote.live/start.airnote.live/` which redirects to the quickstart (actually just a placeholder for now because the quickstart is yet to be competed).