### PR TITLE
feat: show device voltage

### DIFF
--- a/src/routes/Dashboard/Dashboard.svelte
+++ b/src/routes/Dashboard/Dashboard.svelte
@@ -265,9 +265,13 @@
             </strong>
           </div>
           <div>
-            Air Pressure
+            Voltage
+            <button class="svg-button info"
+              on:click={() => tooltipState = TOOLTIP_STATES.VOLTAGE_HELP }>
+              <InfoIcon />
+            </button>
             <strong>
-              {Math.round(lastReading.env_press / 1000)} kPa
+              {Number(lastReading.bat_voltage).toFixed(1)}V
             </strong>
           </div>
         </div>
@@ -319,6 +323,14 @@
         Air Quality Index, or AQI, is the EPA’s index for reporting air quality.
         The higher the AQI value, the greater the level of air pollution and the
         greater the health concern.
+      </p>
+    {/if}
+    {#if tooltipState === TOOLTIP_STATES.VOLTAGE_HELP}
+      <p>
+        The voltage level of the Airnote. Anything over 4 volts indicates the battery
+        is full. If your Airnote is running low on battery, you may want to move your
+        device to an area with more sunlight, or
+        <a href="https://dev.blues.io/hardware/airnote-quickstart/#how-can-i-manually-charge-my-airnote">manually charge the device</a>.
       </p>
     {/if}
     <p>

--- a/src/routes/Dashboard/TooltipStates.js
+++ b/src/routes/Dashboard/TooltipStates.js
@@ -4,4 +4,5 @@ export default {
   PM02_5_HELP: 3,
   PM10_0_HELP: 4,
   AQI_HELP: 5,
+  VOLTAGE_HELP: 6,
 }


### PR DESCRIPTION
Note: This change also removes the air pressure, which we did because a raw air pressure reading is difficult for the average user to interpret, and that value is still available on the linked safecast dashboard.