### PR TITLE
feat: redirect users w/o a pin to the dashboard instead of settings

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,5 +1,6 @@
 <script>
-  import { Router, Route } from 'svelte-routing';
+  import { Router, Route, navigate } from 'svelte-routing';
+  import { onMount } from 'svelte';
 
   import CloseIcon from './icons/CloseIcon.svelte';
   import MenuIcon from './icons/MenuIcon.svelte';
@@ -8,7 +9,8 @@
   import Home from './routes/Home/Home.svelte';
   import { getCurrentDeviceFromUrl } from './services/device';
 
-  const currentDevice = getCurrentDeviceFromUrl(window.location);
+  const location = window.location;
+  const currentDevice = getCurrentDeviceFromUrl(location);
 
   let menuOpen = false;
   const toggleMenu = () => menuOpen = !menuOpen;
@@ -18,12 +20,14 @@
   export let productUID = currentDevice.productUID;
   export let deviceUID = currentDevice.deviceUID;
 
-  // Notehub links to a device’s dashboard using `/${deviceUID}` with no pin,
-  // and we want Notehub users to view the device’s dashboard, and not the
-  // settings page.
-  if (deviceUID && (window.location.pathname === ('/' + deviceUID)) && !pin) {
-    window.location.href = `${window.location.origin}/${deviceUID}/dashboard`;
-  }
+  onMount(() => {
+    // Notehub links to a device’s dashboard using `/${deviceUID}` with no pin,
+    // and we want Notehub users to view the device’s dashboard, and not the
+    // settings page.
+    if (deviceUID && (location.pathname === ('/' + deviceUID)) && !pin) {
+      navigate(`/${deviceUID}/dashboard`, { replace: true });
+    }
+  });
 </script>
 
 <Router {url}>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -17,6 +17,13 @@
   export let pin = currentDevice.pin;
   export let productUID = currentDevice.productUID;
   export let deviceUID = currentDevice.deviceUID;
+
+  // Notehub links to a device’s dashboard using `/${deviceUID}` with no pin,
+  // and we want Notehub users to view the device’s dashboard, and not the
+  // settings page.
+  if (window.location.pathname === ('/' + deviceUID) && !pin) {
+    window.location.href = `${window.location.origin}/${deviceUID}/dashboard`;
+  }
 </script>
 
 <Router {url}>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -21,7 +21,7 @@
   // Notehub links to a device’s dashboard using `/${deviceUID}` with no pin,
   // and we want Notehub users to view the device’s dashboard, and not the
   // settings page.
-  if (window.location.pathname === ('/' + deviceUID) && !pin) {
+  if (deviceUID && (window.location.pathname === ('/' + deviceUID)) && !pin) {
     window.location.href = `${window.location.origin}/${deviceUID}/dashboard`;
   }
 </script>


### PR DESCRIPTION
Notehub has a somewhat obscure feature that allows users to configure a dashboard for their projects...

![Screen Shot 2022-03-30 at 3 32 57 PM](https://user-images.githubusercontent.com/544280/160916116-a7dc92c7-23e5-4a9f-a873-015ec5f97a0d.png)

...and then get a link to them with this dashboard link that appears for all devices.

![Screen Shot 2022-03-30 at 3 34 00 PM](https://user-images.githubusercontent.com/544280/160916308-c54f2135-d536-4095-a677-0998781e74b9.png)

When viewing an Airnote dashboard you must have a `pin` in the URL to change a device’s settings. That pin is included on the URL that’s printed on the physical Airnote enclosure. When viewing an Airnote in Notehub, however, that pin is not present, and users that click that link go to a settings page where they can’t actually change the settings.

This PR redirects users that go to the settings URL, and do not have a pin, to the dashboard where they can view device data.

