### PR TITLE
feat: Better error handling for Airnotes with no recent data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "airnote.live",
       "version": "0.1.0",
       "dependencies": {
         "@beyonk/svelte-notifications": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
-    "start": "sirv public -s",
+    "start": "sirv public --single --port 5555",
     "test": "jest",
     "test:watch": "npm run test -- --watch"
   },

--- a/server/server.js
+++ b/server/server.js
@@ -1,106 +1,111 @@
-'use strict';
-const Hapi = require('@hapi/hapi');
-const axios = require('axios');
+"use strict";
+const Hapi = require("@hapi/hapi");
+const axios = require("axios");
 
 const server = Hapi.server({
   port: 3000,
-  host: '0.0.0.0', // needed for Render deployment
+  host: "0.0.0.0", // needed for Render deployment
 });
 
 const buildBody = (device_uid, to, from) => {
   return {
-    "size": 500,
-    "sort": [
+    size: 500,
+    sort: [
       {
-        "when_captured": {
-          "order": "desc"
-        }
-      }
+        when_captured: {
+          order: "desc",
+        },
+      },
     ],
-    "query": {
-      "bool": {
-        "must": [],
-        "filter": [
+    query: {
+      bool: {
+        must: [],
+        filter: [
           {
-            "bool": {
-              "should": [
+            bool: {
+              should: [
                 {
-                  "match_phrase": {
-                    "device_urn": "note:" + device_uid
-                  }
-                }
-              ]
-            }
+                  match_phrase: {
+                    device_urn: "note:" + device_uid,
+                  },
+                },
+              ],
+            },
           },
           {
-            "range": {
-              "service_uploaded": {
-                "format": "strict_date_optional_time",
-                "gte": from,
-                "lte": to
-              }
-            }
-          }
-        ]
-      }
-    }
+            range: {
+              service_uploaded: {
+                format: "strict_date_optional_time",
+                gte: from,
+                lte: to,
+              },
+            },
+          },
+        ],
+      },
+    },
   };
-}
+};
 
-const url = 'https://40ad140d461d810ac41ed710b5c7a5b6.us-west-2.aws.found.io:9243/_search';
+const url =
+  "https://40ad140d461d810ac41ed710b5c7a5b6.us-west-2.aws.found.io:9243/_search";
 const headers = {
-  'Content-Type': 'application/json',
-  'Authorization': 'Basic ' + new Buffer(process.env.SAFECAST_USERNAME + ':' + process.env.SAFECAST_PASSWORD).toString('base64')
+  "Content-Type": "application/json",
+  Authorization:
+    "Basic " +
+    new Buffer(
+      process.env.SAFECAST_USERNAME + ":" + process.env.SAFECAST_PASSWORD
+    ).toString("base64"),
 };
 
 const init = async () => {
   await server.register([
     {
-      plugin: require('@hapi/inert'),
-      options: {}
+      plugin: require("@hapi/inert"),
+      options: {},
     },
     {
-      plugin: require('hapi-pino'),
+      plugin: require("hapi-pino"),
       options: {
         prettyPrint: true,
-        logEvents: ['response', 'onPostStart']
-      }
-    }]);
+        logEvents: ["response", "onPostStart"],
+      },
+    },
+  ]);
 
   server.route({
-    method: 'GET',
-    path: '/',
+    method: "GET",
+    path: "/",
     options: {
       cors: {
-        origin: [
-          'http://localhost:5000',
-          'https://airnote.live'
-        ]
+        origin: ["http://localhost:5555", "https://airnote.live"],
       },
       handler: async (request, h) => {
         const device_uid = request.query.device_uid;
         const to = request.query.to;
         const from = request.query.from;
-        
+
         try {
-          const response = await axios.post(url, buildBody(device_uid, to, from), {
-            headers: headers,
-          });
-          return h.response(response.data)
-            .type('application/json')
-            .code(200);
-        } catch(err) {
+          const response = await axios.post(
+            url,
+            buildBody(device_uid, to, from),
+            {
+              headers: headers,
+            }
+          );
+          return h.response(response.data).type("application/json").code(200);
+        } catch (err) {
           return h.response().code(500);
         }
-      }
-    }
+      },
+    },
   });
 
   await server.start();
   console.log(`Server running at: ${server.info.uri}`);
 };
 
-process.on('unhandledRejection', (err) => {
+process.on("unhandledRejection", (err) => {
   console.log(err);
   process.exit(1);
 });

--- a/src/routes/Dashboard/Dashboard.svelte
+++ b/src/routes/Dashboard/Dashboard.svelte
@@ -40,6 +40,10 @@
     localStorage.setItem('tempDisplay', tempDisplay);
   }
 
+  const getSafecastDashboardLink = (deviceUID) => (
+    `http://tt.safecast.org/dashboard/note:${deviceUID}`
+  );
+
   const downloadData = () => {
     const csv = 'data:text/csv;charset=utf-8,' +
       unparse(readings);
@@ -105,10 +109,20 @@
   {#if noDataError}
     <div class="alert">
       <h4 class="alert-heading">{NO_DATA_ERROR_HEADING}</h4>
-      There is no data associated with this Airnote. If this is a new Airnote,
-      it may take several hours for your device to report its first readings.
-      For help setting up your Airnote, visit
-      <a href='https://start.airnote.live'>start.airnote.live</a>.
+      <p>
+        There is no recent data associated with this Airnote. If this is a new
+        Airnote, it may take several hours for your device to report its first
+        readings. For help setting up your Airnote, visit
+        <a href='https://start.airnote.live'>start.airnote.live</a>.
+      </p>
+
+      <p>
+        If this is a device that has previously reported readings, you can view
+        historical data on
+        <a href={getSafecastDashboardLink(deviceUID)}>this device’s Safecast dashboard</a>,
+        and <a href="https://discuss.blues.io">reach out on our forum</a> if you need
+        help getting your Airnote back up and running.
+      </p>
     </div>
   {/if}
 
@@ -279,7 +293,7 @@
     </div>
 
     <div class="full-data-link">
-      <a in:fade href="http://tt.safecast.org/dashboard/note:{deviceUID}" class="svg-link" target="_blank">
+      <a in:fade href="{getSafecastDashboardLink(deviceUID)}" class="svg-link" target="_blank">
         <span>View full data</span>
         <ExternalLinkIcon />
       </a>

--- a/src/routes/Dashboard/Dashboard.svelte
+++ b/src/routes/Dashboard/Dashboard.svelte
@@ -110,7 +110,7 @@
     <div class="alert">
       <h4 class="alert-heading">{NO_DATA_ERROR_HEADING}</h4>
       <p>
-        There is no recent data associated with this Airnote. If this is a new
+        This Airnote has not reported data in the last seven days. If this is a new
         Airnote, it may take several hours for your device to report its first
         readings. For help setting up your Airnote, visit
         <a href='https://start.airnote.live'>start.airnote.live</a>.


### PR DESCRIPTION
![Screen Shot 2022-05-25 at 2 22 36 PM](https://user-images.githubusercontent.com/544280/170345471-1e26cda4-a61b-4aa7-9f0f-1b23dfe92ac1.png

If an Airnote has no recent data we show an error. Previously that error only addressed users with new Airnotes (and therefore had no data yet). This PR adds messaging for Airnote users that previously had data, and do not currently.

Story: https://www.pivotaltracker.com/story/show/181203517

There’s also a small workaround in here, because apparently [`localhost:5000` sometimes doesn’t work on macOS](https://github.com/sveltejs/template/issues/184). That was a fun 30 minutes.