### PR TITLE
bug: fix flaky dashboard charts & remove PIN requirements to view settings information

### DIFF
--- a/public/global.css
+++ b/public/global.css
@@ -2,24 +2,27 @@
   --primary: rgb(0, 185, 255);
   --background: rgb(247, 249, 251);
 }
-*, ::after, ::before {
+*,
+::after,
+::before {
   box-sizing: border-box;
 }
-html, body {
+html,
+body {
   position: relative;
   width: 100%;
   height: 100%;
 }
 svg {
-  font-family: 'Barlow', sans-serif;
+  font-family: "Barlow", sans-serif;
 }
 
 body {
-  color: #1B3A52;
+  color: #1b3a52;
   background: var(--background);
   margin: 0;
   box-sizing: border-box;
-  font-family: 'Barlow', sans-serif;
+  font-family: "Barlow", sans-serif;
   font-style: normal;
   font-weight: normal;
   font-size: 16px;
@@ -62,7 +65,8 @@ header .svg-button {
 header .svg-button svg {
   color: white;
 }
-header .svg-button, header .svg-button svg {
+header .svg-button,
+header .svg-button svg {
   /* Safari requires the height on both for whatever reason */
   height: 2rem;
   width: 2rem;
@@ -130,7 +134,8 @@ label {
   color: #416681;
 }
 
-input, select {
+input,
+select {
   font: inherit;
   padding: 0.75rem;
   margin: 0 0 1rem 0;
@@ -141,7 +146,7 @@ input, select {
 select {
   height: 45px;
 }
-input[type=checkbox] {
+input[type="checkbox"] {
   width: auto;
   margin-right: 0.25rem;
   padding: 0;
@@ -150,28 +155,28 @@ input[type=checkbox] {
 .checkbox-label {
   margin-top: 1rem;
 }
-input[type=range]::-webkit-slider-runnable-track {
+input[type="range"]::-webkit-slider-runnable-track {
   width: 100%;
   height: 2px;
   cursor: pointer;
   background: #ced9e1;
   border-radius: 25px;
 }
-input[type=range]::-moz-range-track {
+input[type="range"]::-moz-range-track {
   background: #ced9e1;
   height: 2px;
 }
-input[type=range]::-webkit-slider-thumb {
+input[type="range"]::-webkit-slider-thumb {
   height: 20px;
   width: 20px;
   border-radius: 50%;
-  background: #1B3A52;
-  box-shadow: 0 0 4px 0 rgba(0,0,0, 1);
+  background: #1b3a52;
+  box-shadow: 0 0 4px 0 rgba(0, 0, 0, 1);
   cursor: pointer;
   -webkit-appearance: none;
   margin-top: -8px;
 }
-input[type=range]:disabled::-webkit-slider-thumb {
+input[type="range"]:disabled::-webkit-slider-thumb {
   cursor: default;
   background: gray;
 }
@@ -179,7 +184,8 @@ form button {
   margin-top: 1rem;
 }
 
-button, .btn {
+button,
+.btn {
   background: var(--primary);
   color: white;
   border-radius: 0.3rem;
@@ -187,11 +193,13 @@ button, .btn {
   padding: 0.5rem 1rem;
   font-size: 1rem;
   cursor: pointer;
-  transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out
+  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out,
+    border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 }
-button:hover, .btn:hover {
+button:hover,
+.btn:hover {
   text-decoration: none;
-  background: #009AD4;
+  background: #009ad4;
 }
 
 .svg-button {
@@ -206,8 +214,9 @@ button:hover, .btn:hover {
 .svg-button:hover {
   background: transparent;
 }
-.svg-button svg, .svg-link svg {
-  color: #1B3A52;
+.svg-button svg,
+.svg-link svg {
+  color: #1b3a52;
 }
 .svg-link svg {
   color: var(--primary);
@@ -221,7 +230,7 @@ button:hover, .btn:hover {
 hr {
   margin: 1.5rem 0;
   border: 0;
-  border-top: 1px solid rgba(0, 0, 0, .1);
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
 }
 
 footer {
@@ -229,6 +238,15 @@ footer {
   display: flex;
   justify-content: space-evenly;
   padding-bottom: 2rem;
+}
+
+.warning {
+  color: #66551f;
+  background: #ffeaa7;
+  border: 1px solid #fee283;
+  padding: 1rem;
+  border-radius: 0.25rem;
+  margin-top: 1rem;
 }
 
 .alert {

--- a/server/server.js
+++ b/server/server.js
@@ -47,20 +47,19 @@ const getEvents = (deviceUID, timeframe) => {
 };
 
 // get Airnote env vars by device with PIN - READ WRITE
-const getAirnoteEnvVars = (airnoteProductUID, deviceUID, pin) => {
+const getAirnoteEnvVars = (productUID, deviceUID, pin) => {
   return axios.get(
-    `${NOTEHUB_BASE_URL}/v1/products/${airnoteProductUID}/devices/${deviceUID}/environment_variables_with_pin`,
-    {},
-    { headers: { "Content-Type": "application/json", "X-Auth-Token": pin } }
+    `${NOTEHUB_BASE_URL}/v1/products/${productUID}/devices/${deviceUID}/environment_variables_with_pin`,
+    { headers: { "X-Auth-Token": pin } }
   );
 };
 
 // update Airnote env vars by device with PIN - READ WRITE
-const updateAirnoteEnvVars = (airnoteProductUID, deviceUID, pin, varsBody) => {
+const updateAirnoteEnvVars = (productUID, deviceUID, pin, varsBody) => {
   return axios.put(
-    `${NOTEHUB_BASE_URL}/v1/products/${airnoteProductUID}/devices/${deviceUID}/environment_variables_with_pin`,
+    `${NOTEHUB_BASE_URL}/v1/products/${productUID}/devices/${deviceUID}/environment_variables_with_pin`,
     varsBody,
-    { headers: { "Content-Type": "application/json", "X-Auth-Token": pin } }
+    { headers: { "X-Auth-Token": pin } }
   );
 };
 
@@ -158,13 +157,13 @@ const init = async () => {
     options: {
       cors: CORS_OPTIONS,
       handler: async (request, h) => {
-        const airnoteProductUID = request.query.airnote_product_uid;
+        const productUID = request.query.product_uid;
         const deviceUID = request.query.device_uid;
         const pin = request.query.pin;
         let canModify = false;
         let unauthorized = false;
         let erred;
-        await getAirnoteEnvVars(airnoteProductUID, deviceUID, pin)
+        await getAirnoteEnvVars(productUID, deviceUID, pin)
           .then((response) => {
             canModify = true;
           })
@@ -199,14 +198,14 @@ const init = async () => {
     options: {
       cors: CORS_OPTIONS,
       handler: async (request, h) => {
-        const airnoteProductUID = request.query.airnote_product_uid;
+        const productUID = request.query.product_uid;
         const deviceUID = request.query.device_uid;
         const pin = request.query.pin;
         const varsBody = request.payload;
         let unauthorized = false;
         let successfullyUpdated = false;
         let erred;
-        await updateAirnoteEnvVars(airnoteProductUID, deviceUID, pin, varsBody)
+        await updateAirnoteEnvVars(productUID, deviceUID, pin, varsBody)
           .then((response) => {
             successfullyUpdated = true;
           })

--- a/server/server.js
+++ b/server/server.js
@@ -166,8 +166,6 @@ const init = async () => {
         let erred;
         await getAirnoteEnvVars(airnoteProductUID, deviceUID, pin)
           .then((response) => {
-            console.log("Notehub Response");
-            console.log(response);
             canModify = true;
           })
           .catch((err) => {
@@ -210,8 +208,6 @@ const init = async () => {
         let erred;
         await updateAirnoteEnvVars(airnoteProductUID, deviceUID, pin, varsBody)
           .then((response) => {
-            console.log("Notehub Response");
-            console.log(response);
             successfullyUpdated = true;
           })
           .catch((err) => {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -21,10 +21,9 @@
   export let deviceUID = currentDevice.deviceUID;
 
   onMount(() => {
-    // Notehub links to a device’s dashboard using `/${deviceUID}` with no pin,
-    // and we want Notehub users to view the device’s dashboard, and not the
-    // settings page.
-    if (deviceUID && location.pathname === "/" + deviceUID && !pin) {
+    /* if the Airnote device ID is available the Airnote has most likely been 
+    set up, redirect the user automatically to their dashboard page */
+    if (deviceUID && location.pathname === "/") {
       navigate(`/${deviceUID}/dashboard`, { replace: true });
     }
   });
@@ -35,7 +34,7 @@
     <a href="/">
       <img alt="Airnote logo" src="/images/airnote.svg" />
     </a>
-    {#if deviceUID && pin}
+    {#if deviceUID}
       <ul class={menuOpen ? "open" : ""}>
         <li>
           <a

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -21,9 +21,15 @@
   export let deviceUID = currentDevice.deviceUID;
 
   onMount(() => {
-    /* if the Airnote device ID is available the Airnote has most likely been 
-    set up, redirect the user automatically to their dashboard page */
-    if (deviceUID && location.pathname === "/") {
+    /* Notehub links to a device’s dashboard using `/${deviceUID}` with no pin,
+    and we want Notehub users to view the device’s dashboard, and not the
+    settings page. */
+    if (
+      deviceUID &&
+      location.pathname === "/" + deviceUID &&
+      !pin &&
+      document.referrer.includes("qrgo")
+    ) {
       navigate(`/${deviceUID}/dashboard`, { replace: true });
     }
   });

--- a/src/components/charts/AQIChart.svelte
+++ b/src/components/charts/AQIChart.svelte
@@ -10,7 +10,9 @@
   let ctx;
   let aqiData = [];
 
-  $: getAQIData(readings);
+  $: if (readings) {
+    getAQIData(readings);
+  }
 
   function getAQIData(readings) {
     aqiData = readings.map((reading) => {

--- a/src/components/charts/HumidityChart.svelte
+++ b/src/components/charts/HumidityChart.svelte
@@ -10,7 +10,9 @@
   let ctx;
   let humidityData = [];
 
-  $: getHumidityData(readings);
+  $: if (readings) {
+    getHumidityData(readings);
+  }
 
   function getHumidityData(readings) {
     humidityData = readings.map((reading) => {

--- a/src/components/charts/PMChart.svelte
+++ b/src/components/charts/PMChart.svelte
@@ -12,7 +12,9 @@
   let pm2_5Data = [];
   let pm10Data = [];
 
-  $: getPMData(readings);
+  $: if (readings) {
+    getPMData(readings);
+  }
 
   function getPMData(readings) {
     /* reading.captured comes in as something like 2022-08-22T06:27:38Z, 

--- a/src/components/charts/TempChart.svelte
+++ b/src/components/charts/TempChart.svelte
@@ -15,7 +15,9 @@
 
   const dispatch = createEventDispatcher();
 
-  $: getTempData(readings);
+  $: if (readings) {
+    getTempData(readings);
+  }
 
   function getTempData(readings) {
     tempDataCelsius = readings.map((reading) => {

--- a/src/components/charts/VoltageChart.svelte
+++ b/src/components/charts/VoltageChart.svelte
@@ -16,7 +16,9 @@
   if an Airnote was charging during the time period */
   const MAX_VOLTAGE = 6;
 
-  $: getVoltageData(readings);
+  $: if (readings) {
+    getVoltageData(readings);
+  }
 
   function getVoltageData(readings) {
     voltageData = readings.reverse().map((reading) => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,10 +1,10 @@
 export const airnoteProductUID = "product:org.airnote.solar.v1";
+export const radnoteProductUID = "product:org.airnote.solar.rad.v1";
 export const appUID = "app:2606f411-dea6-44a0-9743-1130f57d77d8";
+
 export const DATE_FORMAT_KEY = "MMMM dd yyyy";
 export const DATE_TIME_FORMAT_KEY = "MM-dd HH:mm";
 export const DATE_TIME_KEY = "MMM dd yyyy HH:mm a";
-export const NO_DATA_ERROR_HEADING = "No data";
-export const FETCH_ERROR_HEADING = "Unable to fetch device details";
 
 // Injected by Rollup
 export const NOTEHUB_API_URL = process.env.NOTEHUB_API_URL;

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,6 @@
-export const airnoteProductUID = "product:org.airnote.solar.v1";
-export const radnoteProductUID = "product:org.airnote.solar.rad.v1";
-export const appUID = "app:2606f411-dea6-44a0-9743-1130f57d77d8";
+export const AIRNOTE_PRODUCT_UID = "product:org.airnote.solar.v1";
+export const RADNOTE_PRODUCT_UID = "product:org.airnote.solar.rad.v1";
+export const APP_UID = "app:2606f411-dea6-44a0-9743-1130f57d77d8";
 
 export const DATE_FORMAT_KEY = "MMMM dd yyyy";
 export const DATE_TIME_FORMAT_KEY = "MM-dd HH:mm";

--- a/src/constants/ErrorTypes.js
+++ b/src/constants/ErrorTypes.js
@@ -1,0 +1,7 @@
+export const ERROR_TYPE = {
+  NOTEHUB_ERROR: "Notehub error",
+  MISSING_PIN: "No PIN",
+  INVALID_PIN: "Invalid PIN",
+  UPDATE_ERROR: "Updating device settings failed.",
+  NO_DATA_ERROR: "No data",
+};

--- a/src/routes/Dashboard/Dashboard.svelte
+++ b/src/routes/Dashboard/Dashboard.svelte
@@ -26,7 +26,8 @@
   import { getHeatIndex, toFahrenheit, toCelsius } from "../../services/air";
   import { getReadings } from "../../services/device";
   import { shareDashboard } from "../../util/share";
-  import { NO_DATA_ERROR_HEADING, FETCH_ERROR_HEADING } from "../../constants";
+  import { ERROR_TYPE } from "../../constants/ErrorTypes";
+  import { renderErrorMessage } from "../../util/errors";
 
   export let deviceUID;
 
@@ -34,8 +35,8 @@
   let readings;
   let history;
 
-  let noDataError = false;
-  let fetchError = false;
+  let error = false;
+  let errorType;
   let loading = true;
 
   let tempDisplay = localStorage.getItem("tempDisplay") || "C";
@@ -77,7 +78,8 @@
       })
       .catch((err) => {
         console.error(err);
-        fetchError = true;
+        error = true;
+        errorType = ERROR_TYPE.NOTEHUB_ERROR;
       });
   }
 
@@ -86,7 +88,8 @@
       .then((data) => {
         lastReading = data.readings[0];
         if (!lastReading) {
-          noDataError = true;
+          error = true;
+          errorType = ERROR_TYPE.NO_DATA_ERROR;
         } else {
           lastReading.heatIndex = getHeatIndex({
             temperature: toFahrenheit(lastReading.temperature),
@@ -98,7 +101,8 @@
       })
       .catch((err) => {
         console.error(err);
-        fetchError = true;
+        error = true;
+        errorType = ERROR_TYPE.NOTEHUB_ERROR;
         loading = false;
       });
   });
@@ -126,31 +130,8 @@
     <div class="loading" />
   {/if}
 
-  {#if noDataError}
-    <div class="alert">
-      <h4 class="alert-heading">{NO_DATA_ERROR_HEADING}</h4>
-      <p>
-        This Airnote has not reported data in the last seven days. If this is a
-        new Airnote, it may take several hours for your device to report its
-        first readings. For help setting up your Airnote, visit
-        <a href="https://start.airnote.live">start.airnote.live</a>.
-      </p>
-
-      <p>
-        If this is a device that has previously reported readings, you can <a
-          href="https://discuss.blues.io">reach out on our forum</a
-        > if you need help getting your Airnote back up and running.
-      </p>
-    </div>
-  {/if}
-
-  {#if fetchError}
-    <div class="alert">
-      <h4 class="alert-heading">{FETCH_ERROR_HEADING}</h4>
-      Please make sure your Airnote is online and connected before visiting this
-      page. For help getting started, visit
-      <a href="https://start.airnote.live" target="_new">start.airnote.live</a>.
-    </div>
+  {#if error}
+    {@html renderErrorMessage(errorType)}
   {/if}
 
   {#if lastReading}

--- a/src/routes/Dashboard/Dashboard.svelte
+++ b/src/routes/Dashboard/Dashboard.svelte
@@ -105,6 +105,10 @@
       ? "— " + lastReading.serial_number
       : ""}</title
   >
+  <link
+    href="https://api.mapbox.com/mapbox-gl-js/v2.9.2/mapbox-gl.css"
+    rel="stylesheet"
+  />
 </svelte:head>
 
 <NotificationDisplay />

--- a/src/routes/Dashboard/Dashboard.svelte
+++ b/src/routes/Dashboard/Dashboard.svelte
@@ -70,10 +70,15 @@
 
   $: if (selectedDateRange) {
     const convertedTimeframe = convertDateRange(selectedDateRange);
-    getReadings(deviceUID, convertedTimeframe).then((data) => {
-      // only update the data for the charts, not the AQI average history component
-      readings = data.readings;
-    });
+    getReadings(deviceUID, convertedTimeframe)
+      .then((data) => {
+        // only update the data for the charts, not the AQI average history component
+        readings = data.readings;
+      })
+      .catch((err) => {
+        console.error(err);
+        fetchError = true;
+      });
   }
 
   onMount(() => {

--- a/src/routes/Dashboard/MapboxMap.svelte
+++ b/src/routes/Dashboard/MapboxMap.svelte
@@ -75,13 +75,6 @@
   });
 </script>
 
-<svelte:head>
-  <link
-    href="https://api.mapbox.com/mapbox-gl-js/v2.9.2/mapbox-gl.css"
-    rel="stylesheet"
-  />
-</svelte:head>
-
 {#if lastReading.lon && lastReading.lat}
   <div in:fade>
     <div class="map-heading">

--- a/src/routes/Settings/Settings.svelte
+++ b/src/routes/Settings/Settings.svelte
@@ -3,11 +3,7 @@
   import { NotificationDisplay, notifier } from "@beyonk/svelte-notifications";
   import DeviceSettings from "./DeviceSettings.svelte";
   import DeviceOwner from "./DeviceOwner.svelte";
-  import {
-    airnoteProductUID,
-    appUID,
-    radnoteProductUID,
-  } from "../../constants";
+  import { APP_UID, RADNOTE_PRODUCT_UID } from "../../constants";
   import { ERROR_TYPE } from "../../constants/ErrorTypes";
   import { renderErrorMessage } from "../../util/errors";
   import {
@@ -35,7 +31,7 @@
   let errorType;
   let notify;
 
-  let eventsUrl = `https://notehub.io/project/${appUID}/events?queryMode=devices&queryDevices=${deviceUID}`;
+  let eventsUrl = `https://notehub.io/project/${APP_UID}/events?queryMode=devices&queryDevices=${deviceUID}`;
 
   const displayOptions = [
     { value: "tempc", text: "Temp (°C)" },
@@ -44,7 +40,7 @@
     { value: "press", text: "Barometric Pressue" },
   ];
 
-  if (productUID === radnoteProductUID) {
+  if (productUID === RADNOTE_PRODUCT_UID) {
     $displayValue = "usv";
 
     displayOptions.splice(0, 0, {
@@ -110,7 +106,7 @@
   const handleSettingsSave = () => {
     const varsBody = createBodyFromStore();
 
-    updateDeviceEnvVars(airnoteProductUID, deviceUID, pin, varsBody)
+    updateDeviceEnvVars(productUID, deviceUID, pin, varsBody)
       .then((data) => {
         if (data.successfullyUpdated) {
           notifier.success("Settings saved.");
@@ -142,9 +138,10 @@
     if (pin === "") {
       error = true;
       errorType = ERROR_TYPE.MISSING_PIN;
+      enableFields = true;
     } else {
       // if pin exists, check its validity to change device settings
-      checkDeviceEnvVarModificationAccess(airnoteProductUID, deviceUID, pin)
+      checkDeviceEnvVarModificationAccess(productUID, deviceUID, pin)
         .then((data) => {
           // if pin is valid, enable inputs
           if (data.canModify) {

--- a/src/routes/Settings/Settings.svelte
+++ b/src/routes/Settings/Settings.svelte
@@ -138,7 +138,6 @@
     if (pin === "") {
       error = true;
       errorType = ERROR_TYPE.MISSING_PIN;
-      enableFields = true;
     } else {
       // if pin exists, check its validity to change device settings
       checkDeviceEnvVarModificationAccess(productUID, deviceUID, pin)

--- a/src/services/device.js
+++ b/src/services/device.js
@@ -94,18 +94,45 @@ export function checkDeviceEnvVarModificationAccess(
   deviceUID,
   pin
 ) {
-  return fetch(
-    `${SERVER_URL}/settings-modification-access?` +
-      new URLSearchParams({
-        airnote_product_uid: airnoteProductUID,
-        device_uid: deviceUID,
-        pin,
+  return (
+    fetch(
+      `${SERVER_URL}/settings-modification-access?` +
+        new URLSearchParams({
+          airnote_product_uid: airnoteProductUID,
+          device_uid: deviceUID,
+          pin,
+        })
+    )
+      .then((response) => response.json())
+      // this returns a true/false bool
+      .then((data) => {
+        return { canModify: data };
       })
-  )
-    .then((response) => response.json())
-    .then((data) => {
-      return { canModify: data };
-    });
+  );
+}
+
+export function updateDeviceEnvVars(
+  airnoteProductUID,
+  deviceUID,
+  pin,
+  varsBody
+) {
+  return (
+    fetch(
+      `${SERVER_URL}/settings-update?` +
+        new URLSearchParams({
+          airnote_product_uid: airnoteProductUID,
+          device_uid: deviceUID,
+          pin,
+        }),
+      { method: "PUT", body: JSON.stringify(varsBody) }
+    )
+      .then((response) => response.json())
+      // this returns a true/false bool
+      .then((data) => {
+        return { successfullyUpdated: data };
+      })
+  );
 }
 
 function saveLastViewedDevice(data) {

--- a/src/services/device.js
+++ b/src/services/device.js
@@ -1,4 +1,4 @@
-import { DATE_FORMAT_KEY, SERVER_URL, airnoteProductUID } from "../constants";
+import { DATE_FORMAT_KEY, SERVER_URL, AIRNOTE_PRODUCT_UID } from "../constants";
 import { format } from "date-fns";
 import queryString from "query-string";
 
@@ -90,7 +90,7 @@ export function getDeviceEnvVars(deviceUID) {
 }
 
 export function checkDeviceEnvVarModificationAccess(
-  airnoteProductUID,
+  productUID,
   deviceUID,
   pin
 ) {
@@ -98,7 +98,7 @@ export function checkDeviceEnvVarModificationAccess(
     fetch(
       `${SERVER_URL}/settings-modification-access?` +
         new URLSearchParams({
-          airnote_product_uid: airnoteProductUID,
+          product_uid: productUID,
           device_uid: deviceUID,
           pin,
         })
@@ -111,17 +111,12 @@ export function checkDeviceEnvVarModificationAccess(
   );
 }
 
-export function updateDeviceEnvVars(
-  airnoteProductUID,
-  deviceUID,
-  pin,
-  varsBody
-) {
+export function updateDeviceEnvVars(productUID, deviceUID, pin, varsBody) {
   return (
     fetch(
       `${SERVER_URL}/settings-update?` +
         new URLSearchParams({
-          airnote_product_uid: airnoteProductUID,
+          product_uid: productUID,
           device_uid: deviceUID,
           pin,
         }),
@@ -148,7 +143,7 @@ export function getCurrentDeviceFromUrl(location) {
 
   const query = queryString.parse(location.search);
   let pin = query["pin"] || "";
-  let productUID = query["product"] || airnoteProductUID;
+  let productUID = query["product"] || AIRNOTE_PRODUCT_UID;
   let deviceUID = location.pathname.match(/dev:\d*/)?.[0] || "";
 
   // If there is no device in the query string default to the

--- a/src/services/device.js
+++ b/src/services/device.js
@@ -79,6 +79,35 @@ export function getReadings(deviceUID, timeframe) {
     });
 }
 
+export function getDeviceEnvVars(deviceUID) {
+  return fetch(
+    `${SERVER_URL}/settings?` + new URLSearchParams({ device_uid: deviceUID })
+  )
+    .then((response) => response.json())
+    .then((data) => {
+      return data;
+    });
+}
+
+export function checkDeviceEnvVarModificationAccess(
+  airnoteProductUID,
+  deviceUID,
+  pin
+) {
+  return fetch(
+    `${SERVER_URL}/settings-modification-access?` +
+      new URLSearchParams({
+        airnote_product_uid: airnoteProductUID,
+        device_uid: deviceUID,
+        pin,
+      })
+  )
+    .then((response) => response.json())
+    .then((data) => {
+      return { canModify: data };
+    });
+}
+
 function saveLastViewedDevice(data) {
   localStorage.setItem("device", JSON.stringify(data));
 }

--- a/src/util/errors.js
+++ b/src/util/errors.js
@@ -39,7 +39,7 @@ export function renderErrorMessage(errorType) {
           It appears you do not have permission to edit settings, just view. 
           If you believe you are receiving this message in error, please try 
           scanning your Airnote QR code on the back of the device or 
-          reviewing our documentation on how to setup your Airnote, 
+          reviewing our documentation on how to set up your Airnote, 
           <a href="https://start.airnote.live" target="_new">here</a>.
         </div>`;
     case errorType === ERROR_TYPE.UPDATE_ERROR:

--- a/src/util/errors.js
+++ b/src/util/errors.js
@@ -1,0 +1,66 @@
+import { ERROR_TYPE } from "../constants/ErrorTypes";
+
+export function renderErrorMessage(errorType) {
+  switch (true) {
+    case errorType === ERROR_TYPE.NOTEHUB_ERROR:
+      return `
+        <div class="alert">
+          <h4 class="alert-heading">Unable to fetch device details.</h4>
+          Please make sure your Airnote is
+          <a href={eventsUrl} target="_new"> online and connected to Notehub.io </a>
+          before visiting this page. For help getting started, visit
+          <a href="https://start.airnote.live" target="_new">
+            start.airnote.live
+          </a>
+          .
+        </div>`;
+    case errorType === ERROR_TYPE.NO_DATA_ERROR:
+      return `
+        <div class="alert">
+          <h4 class="alert-heading">No data</h4>
+          <p>
+            This Airnote has not reported data in the last seven days. If this
+            is a new Airnote, it may take several hours for your device to
+            report its first readings. For help setting up your Airnote, visit
+            <a href="https://start.airnote.live">start.airnote.live</a>.
+          </p>
+
+          <p>
+            If this is a device that has previously reported readings, you can{" "}
+            <a href="https://discuss.blues.io">reach out on our forum</a> if you
+            need help getting your Airnote back up and running.
+          </p>
+        </div>`;
+    case errorType === ERROR_TYPE.MISSING_PIN:
+    case errorType === ERROR_TYPE.INVALID_PIN:
+      return `
+        <div class="alert">
+          <h4 class="alert-heading">No PIN or invalid PIN detected.</h4>
+          You can view but not change any of these device settings. This error
+          message needs more actionable steps to resolve an issue but I don't
+          know what to say.
+        </div>`;
+    case errorType === ERROR_TYPE.UPDATE_ERROR:
+      return `
+         <div class="warning">
+          <h4 class="alert-heading">
+            Unable to save new configuration settings. Please try again later.
+          </h4>
+        </div>`;
+    default:
+      return `
+        <div class="alert">
+          <h4 class="alert-heading">Unable to fetch device details.</h4>
+          Please make sure your Airnote is
+          <a href={eventsUrl} target="_new">
+            {" "}
+            online and connected to Notehub.io{" "}
+          </a>
+          before visiting this page. For help getting started, visit
+          <a href="https://start.airnote.live" target="_new">
+            start.airnote.live
+          </a>
+          .
+        </div>`;
+  }
+}

--- a/src/util/errors.js
+++ b/src/util/errors.js
@@ -26,7 +26,7 @@ export function renderErrorMessage(errorType) {
           </p>
 
           <p>
-            If this is a device that has previously reported readings, you can{" "}
+            If this is a device that has previously reported readings, you can 
             <a href="https://discuss.blues.io">reach out on our forum</a> if you
             need help getting your Airnote back up and running.
           </p>
@@ -52,10 +52,7 @@ export function renderErrorMessage(errorType) {
         <div class="alert">
           <h4 class="alert-heading">Unable to fetch device details.</h4>
           Please make sure your Airnote is
-          <a href={eventsUrl} target="_new">
-            {" "}
-            online and connected to Notehub.io{" "}
-          </a>
+          <a href={eventsUrl} target="_new"> online and connected to Notehub.io </a>
           before visiting this page. For help getting started, visit
           <a href="https://start.airnote.live" target="_new">
             start.airnote.live

--- a/src/util/errors.js
+++ b/src/util/errors.js
@@ -35,17 +35,17 @@ export function renderErrorMessage(errorType) {
     case errorType === ERROR_TYPE.INVALID_PIN:
       return `
         <div class="alert">
-          <h4 class="alert-heading">No PIN or invalid PIN detected.</h4>
-          You can view but not change any of these device settings. This error
-          message needs more actionable steps to resolve an issue but I don't
-          know what to say.
+          <h4 class="alert-heading">Unauthorized</h4>
+          It appears you do not have permission to edit settings, just view. 
+          If you believe you are receiving this message in error, please try 
+          scanning your Airnote QR code on the back of the device or 
+          reviewing our documentation on how to setup your Airnote, 
+          <a href="https://start.airnote.live" target="_new">here</a>.
         </div>`;
     case errorType === ERROR_TYPE.UPDATE_ERROR:
       return `
          <div class="warning">
-          <h4 class="alert-heading">
             Unable to save new configuration settings. Please try again later.
-          </h4>
         </div>`;
     default:
       return `

--- a/tests/routes/Dashboard/Dashboard.test.js
+++ b/tests/routes/Dashboard/Dashboard.test.js
@@ -1,14 +1,13 @@
 import { render, waitFor } from "@testing-library/svelte";
 
 import Dashboard from "../../../src/routes/Dashboard/Dashboard.svelte";
-import {
-  NO_DATA_ERROR_HEADING,
-  FETCH_ERROR_HEADING,
-} from "../../../src/constants";
+import { ERROR_TYPE } from "../../../src/constants/ErrorTypes";
 
 beforeEach(() => {
   fetch.mockClear();
 });
+
+const FETCH_ERROR_HEADING_TEXT = "Unable to fetch device details.";
 
 test("If there’s an error getting readings the user should see an error", async () => {
   fetch.mockImplementationOnce(() => Promise.reject());
@@ -16,11 +15,11 @@ test("If there’s an error getting readings the user should see an error", asyn
     deviceUID: "...",
   });
 
-  let errorHeading = await waitFor(() => getByText(FETCH_ERROR_HEADING));
+  let errorHeading = await waitFor(() => getByText(FETCH_ERROR_HEADING_TEXT));
   expect(errorHeading).toBeInTheDocument();
 
   // Do NOT show the no data error
-  errorHeading = queryByText(NO_DATA_ERROR_HEADING);
+  errorHeading = queryByText(ERROR_TYPE.NO_DATA_ERROR);
   expect(errorHeading).toBe(null);
 });
 
@@ -34,11 +33,11 @@ test("If the API returns no data the user should see a no-data error", async () 
     deviceUID: "...",
   });
 
-  let errorHeading = await waitFor(() => getByText(NO_DATA_ERROR_HEADING));
+  let errorHeading = await waitFor(() => getByText(ERROR_TYPE.NO_DATA_ERROR));
   expect(errorHeading).toBeInTheDocument();
 
   // Do NOT show the fetch error
-  errorHeading = queryByText(FETCH_ERROR_HEADING);
+  errorHeading = queryByText(FETCH_ERROR_HEADING_TEXT);
   expect(errorHeading).toBe(null);
 });
 
@@ -68,6 +67,6 @@ appropriately.
 
 //   await waitFor(() => getByText("Air Quality"));
 
-//   expect(queryByText(FETCH_ERROR_HEADING)).toBe(null);
-//   expect(queryByText(NO_DATA_ERROR_HEADING)).toBe(null);
+//   expect(queryByText(FETCH_ERROR_HEADING_TEXT)).toBe(null);
+//   expect(queryByText(ERROR_TYPE.NO_DATA_ERROR)).toBe(null);
 // });

--- a/tests/routes/Dashboard/Dashboard.test.js
+++ b/tests/routes/Dashboard/Dashboard.test.js
@@ -1,5 +1,4 @@
-import { render, waitFor } from "@testing-library/svelte";
-
+import { render } from "@testing-library/svelte";
 import Dashboard from "../../../src/routes/Dashboard/Dashboard.svelte";
 import { ERROR_TYPE } from "../../../src/constants/ErrorTypes";
 

--- a/tests/routes/Dashboard/Dashboard.test.js
+++ b/tests/routes/Dashboard/Dashboard.test.js
@@ -10,12 +10,12 @@ beforeEach(() => {
 const FETCH_ERROR_HEADING_TEXT = "Unable to fetch device details.";
 
 test("If there’s an error getting readings the user should see an error", async () => {
-  fetch.mockImplementationOnce(() => Promise.reject());
-  const { getByText, queryByText } = render(Dashboard, {
+  fetch.mockImplementation(() => Promise.reject());
+  const { findByText, queryByText } = render(Dashboard, {
     deviceUID: "...",
   });
 
-  let errorHeading = await waitFor(() => getByText(FETCH_ERROR_HEADING_TEXT));
+  let errorHeading = await findByText(FETCH_ERROR_HEADING_TEXT);
   expect(errorHeading).toBeInTheDocument();
 
   // Do NOT show the no data error
@@ -24,16 +24,16 @@ test("If there’s an error getting readings the user should see an error", asyn
 });
 
 test("If the API returns no data the user should see a no-data error", async () => {
-  fetch.mockImplementationOnce(() =>
+  fetch.mockImplementation(() =>
     Promise.resolve({
       json: () => Promise.resolve([]),
     })
   );
-  const { getByText, queryByText } = render(Dashboard, {
+  const { findByText, queryByText } = render(Dashboard, {
     deviceUID: "...",
   });
 
-  let errorHeading = await waitFor(() => getByText(ERROR_TYPE.NO_DATA_ERROR));
+  let errorHeading = await findByText(ERROR_TYPE.NO_DATA_ERROR);
   expect(errorHeading).toBeInTheDocument();
 
   // Do NOT show the fetch error

--- a/tests/routes/Dashboard/Settings.test.js
+++ b/tests/routes/Dashboard/Settings.test.js
@@ -7,7 +7,7 @@ beforeEach(() => {
 });
 
 const FETCH_ERROR_HEADING_TEXT = "Unable to fetch device details.";
-const NO_PIN_INVALID_PIN = "No PIN or invalid PIN detected.";
+const UNAUTHORIZED = "Unauthorized";
 const UNABLE_TO_SAVE_SETTINGS = "Unable to save new configuration settings.";
 
 test("If there is an error fetching device settings data, the user should see an appropriate error message", async () => {
@@ -36,7 +36,7 @@ test("If the user is not allowed to update the input fields because of a missing
     pin: "",
   });
 
-  let errorHeading = await findByText(NO_PIN_INVALID_PIN);
+  let errorHeading = await findByText(UNAUTHORIZED);
   let deviceSettingsUpdateButton = queryByText("Update Device Settings");
   let deviceOwnerInfoUpdateButton = queryByText("Update Device Owner");
 

--- a/tests/routes/Dashboard/Settings.test.js
+++ b/tests/routes/Dashboard/Settings.test.js
@@ -1,0 +1,74 @@
+import { render, screen, fireEvent } from "@testing-library/svelte";
+
+import Settings from "../../../src/routes/Settings/Settings.svelte";
+
+beforeEach(() => {
+  fetch.mockClear();
+});
+
+const FETCH_ERROR_HEADING_TEXT = "Unable to fetch device details.";
+const NO_PIN_INVALID_PIN = "No PIN or invalid PIN detected.";
+const UNABLE_TO_SAVE_SETTINGS = "Unable to save new configuration settings.";
+
+test("If there is an error fetching device settings data, the user should see an appropriate error message", async () => {
+  fetch.mockImplementation(() => Promise.reject());
+
+  const { findByText } = render(Settings, {
+    deviceUID: "dev.testAirnote",
+    productUID: "faux.airnote",
+    pin: 1234,
+  });
+
+  let errorHeading = await findByText(FETCH_ERROR_HEADING_TEXT);
+  expect(errorHeading).toBeInTheDocument();
+});
+
+test("If the user is not allowed to update the input fields because of a missing PIN, there should be an appropriate error message displayed", async () => {
+  fetch.mockImplementation(() =>
+    Promise.resolve({
+      json: () => Promise.resolve({ canModify: false }),
+    })
+  );
+
+  const { findByText, queryByText } = render(Settings, {
+    deviceUID: "dev.testAirnote",
+    productUID: "faux.airnote",
+    pin: "",
+  });
+
+  let errorHeading = await findByText(NO_PIN_INVALID_PIN);
+  let deviceSettingsUpdateButton = queryByText("Update Device Settings");
+  let deviceOwnerInfoUpdateButton = queryByText("Update Device Owner");
+
+  expect(errorHeading).toBeInTheDocument();
+  expect(deviceSettingsUpdateButton).not.toBeInTheDocument();
+  expect(deviceOwnerInfoUpdateButton).not.toBeInTheDocument();
+});
+
+test("If the user is allowed to update the input fields, when they save their changes, they should recieve a success message", async () => {
+  fetch.mockImplementation(() =>
+    Promise.resolve({
+      json: () => Promise.resolve({ successfullyUpdated: true }),
+    })
+  );
+
+  const { findByText, queryByText } = render(Settings, {
+    deviceUID: "dev.testAirnote",
+    productUID: "faux.airnote",
+    pin: "123456",
+  });
+
+  let deviceNameInput = await screen.findByPlaceholderText("my-airnote-name");
+  await fireEvent.change(deviceNameInput, {
+    target: { value: "My Test Airnote" },
+  });
+  expect(deviceNameInput.value).toBe("My Test Airnote");
+  let deviceSettingsUpdateButton = await findByText("Update Device Settings");
+  await fireEvent.click(deviceSettingsUpdateButton);
+
+  let errorHeading = queryByText(UNABLE_TO_SAVE_SETTINGS);
+  let successMessage = await findByText("Settings saved.");
+
+  expect(errorHeading).not.toBeInTheDocument();
+  expect(successMessage).toBeInTheDocument();
+});

--- a/tests/services/device.test.js
+++ b/tests/services/device.test.js
@@ -1,4 +1,4 @@
-import { airnoteProductUID } from "../../src/constants";
+import { AIRNOTE_PRODUCT_UID } from "../../src/constants";
 import {
   checkDeviceEnvVarModificationAccess,
   getCurrentDeviceFromUrl,
@@ -114,7 +114,7 @@ test("If the device changes in the URL the data should change as well", () => {
   });
   expect(thirdDevice.deviceUID).toBe("dev:333");
   expect(thirdDevice.pin).toBe("");
-  expect(thirdDevice.productUID).toBe(airnoteProductUID);
+  expect(thirdDevice.productUID).toBe(AIRNOTE_PRODUCT_UID);
 });
 
 test("If the device is removed from the URL the last device viewed should persist", () => {

--- a/tests/services/device.test.js
+++ b/tests/services/device.test.js
@@ -1,6 +1,7 @@
 import { airnoteProductUID } from "../../src/constants";
 import {
   getCurrentDeviceFromUrl,
+  getDeviceEnvVars,
   getReadings,
 } from "../../src/services/device";
 
@@ -127,4 +128,27 @@ test("If the device is removed from the URL the last device viewed should persis
   expect(device.deviceUID).toBe("dev:111");
   expect(device.pin).toBe("111111");
   expect(device.productUID).toBe("product:org.airnote.solar.v1");
+});
+
+test("It should return the device's environment variables if device ID is supplied", () => {
+  fetch.mockImplementationOnce(() =>
+    Promise.resolve({
+      json: () =>
+        Promise.resolve({
+          _air_indoors: "0",
+          _air_mins: "usb:15;high:30;normal:30;low:720;0",
+          _air_status: "pm2.5",
+          _contact_affiliation: "Test Account",
+          _contact_email: "test@test.com",
+          _contact_name: "Tester",
+          _sn: "test-airnote",
+        }),
+    })
+  );
+
+  getDeviceEnvVars("dev:864475044215258").then((data) => {
+    expect(data._air_indoors).toBe("0");
+    expect(data._contact_email).toBe("test@test.com");
+    expect(data._sn).toBe("test-airnote");
+  });
 });


### PR DESCRIPTION
# Problem Context

This PR tackles three main problems:

1. Intermittently the dashboard fails to load and gives a white screen of death, which I believe is due to it attempting to render charts before there's data back from Notehub to render the charts with. 
2. The `Unable to fetch device details` error shows in the Settings page when the user has an invalid PIN for the current Airnote device UID. This is confusing and incorrect, if the PIN's invalid, we should show them an indicator of that but still let them view individual Airnote data, just not update it.
3. If a user has an Airnote's device ID, the Settings and Dashboard links should always be visible in the header even if a user has no PIN - they should just not be allowed to be updated unless the correct PIN for a particular Airnote is present.

## Changes

- Fix up all the charts to no longer try to render before their readings from Notehub have been fetched, and add more error handling to handle it if data fails to come back.
- Decouple main dashboard from relying on both device ID and PIN to view the `Settings` and `Dashboard` links in the nav bar (now a user must only have a device ID to be able to see all aspects of an Airnote)
- Consolidate all error messaging for the app into a set of constants and a function to render the appropriate HTML message based on the `errorType` passed in.
- Decouple settings page from depending on a valid PIN to display Airnote device details. Now, the details are displayed regardless of PIN status, but the input boxes are left disabled if the PIN is missing entirely or invalid and an appropriate error message is displayed (I'm still working on the exact messaging with Michelle)
- Move all API calls in the app to the `server.js` file instead of letting any originate out of the client, and use the `device.js` file as the routing connection between the client and server.
- Fix broken unit tests and add a few more for the increased functionality of the `Settings.svelte` file and `device.js` file.

## Screenshot (if applicable)

Valid PIN no longer required to see Airnote device info (but inputs disabled if that's the case)

![Screen Shot 2022-08-26 at 5 06 16 PM](https://user-images.githubusercontent.com/20400845/186990768-a9fccac5-0a6f-4414-b7c9-26901baa01cd.png)

## Testing

Unit / integration / e2e tests?

Additional unit tests added.

Steps to test manually?

To test if the navbar links render in the browser without a pin required,
1.  Open an incognito browser window and go to: http://localhost:5555/dev:864475044215258/dashboard
2. You should land on the dashboard of an Airnote and be able to see the nav bar links
3. Click the "settings" link
4. Observe you can see the settings page and all the Airnote settings, but the URL has a query param of `&pin=` that is empty and there's an error message stating the PIN is missing or invalid and so users can look but not change settings for this Airnote.

To test if the dashboard always renders correctly and never gives a white screen of death:
1. Go to: http://localhost:5555/dev:864475044215258/dashboard
2. Refresh the page several times and see the dashboard continue to render correctly every time, no intermittent errors happening where the screen goes blank except for header and footer.

Any other sorts of testing notes to include?

I'm still working out the final wording with Michelle for the error messaging on the Settings page when users have a missing or invalid PIN or fail to save their device changes to Notehub.

## Any other related PRs

n/a

## Ticket(s)

https://trello.com/c/fktDJ3CT/7-handle-ui-bugs-where-the-page-breaks-when-the-data-from-notehub-is-not-yet-present-or-user-has-invalid-pin-when-hitting-the-sett

https://trello.com/c/w09Pzulr/6-make-settings-and-dashboards-links-always-visible-in-airnote-header
