### PR TITLE
fix: Ensuring Notehub "dashboard" links correctly redirect to Airnote dashbaords

### DIFF
--- a/cypress/e2e/airnote-pages.spec.cy.js
+++ b/cypress/e2e/airnote-pages.spec.cy.js
@@ -50,6 +50,26 @@ describe("Airnote application", () => {
       .and("include", "https://notehub.io");
   });
 
+  it("Redirects Notehub 'Dashboard' links to the Airnote dashboard", () => {
+    // visit the settings page with no pin
+    cy.visit(
+      "/dev:864475044215258?product=product%3Aorg.airnote.solar.air.v1&pin="
+    );
+    // should redirect to the dashboard
+    cy.url().should("include", "dashboard");
+  });
+
+  it("Does NOT redirect internal navigation back to the dashboard", () => {
+    // visit the dashboard page with no pin
+    cy.visit(
+      "/dev:864475044215258/dashboard?product=product%3Aorg.airnote.solar.air.v1&pin="
+    );
+    // navigate to settings page
+    cy.get('[data-cy="settings-link"]').click();
+    //should not redirect back to the dashboard
+    cy.url().should("not.contain", "dashboard");
+  });
+
   it("should navigate to the Airnote dashboard page and render the correct data", () => {
     cy.setLocalStorage();
     cy.visit("/");

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -19,6 +19,7 @@
   export let pin = currentDevice.pin;
   export let productUID = currentDevice.productUID;
   export let deviceUID = currentDevice.deviceUID;
+  export let internalNav = currentDevice.internalNav;
 
   onMount(() => {
     /* Notehub links to a device’s dashboard using `/${deviceUID}` with no pin,
@@ -28,7 +29,7 @@
       deviceUID &&
       location.pathname === "/" + deviceUID &&
       !pin &&
-      document.referrer.includes("qrgo")
+      !internalNav
     ) {
       navigate(`/${deviceUID}/dashboard`, { replace: true });
     }
@@ -44,7 +45,7 @@
       <ul class={menuOpen ? "open" : ""}>
         <li>
           <a
-            href="/{deviceUID}?product={productUID}&pin={pin}"
+            href="/{deviceUID}?product={productUID}&pin={pin}&internalNav=true"
             data-cy="settings-link"
           >
             Settings

--- a/src/services/device.js
+++ b/src/services/device.js
@@ -145,6 +145,7 @@ export function getCurrentDeviceFromUrl(location) {
   let pin = query["pin"] || "";
   let productUID = query["product"] || AIRNOTE_PRODUCT_UID;
   let deviceUID = location.pathname.match(/dev:\d*/)?.[0] || "";
+  let internalNav = query["internalNav"];
 
   // If there is no device in the query string default to the
   // last viewed device.
@@ -166,6 +167,9 @@ export function getCurrentDeviceFromUrl(location) {
   if (deviceUID) {
     saveLastViewedDevice(currentDevice);
   }
+
+  // Don’t save whether this was internal navigation in local storage
+  currentDevice.internalNav = internalNav;
 
   return currentDevice;
 }


### PR DESCRIPTION
# Problem Context

The changes to always show the “Settings” link in the UI (https://github.com/blues/airnote.live/commit/a53a9467947c2c82146d2d3f24860f7b5cba1ea0) made it difficult to additionally redirect Notehub users that use the “Dashboard” link that appears on Notehub devices.

## Changes

This change restores the Notehub redirect, and uses an `"internalNav"` query string parameter to ensure the redirect does _not_ occur to users within the Airnote app itself.

## Testing

We added two new Cypress tests to verify this functionality.

## Ticket(s)

https://trello.com/c/zC9qnP10/10-remove-unnecessary-redirect-log-on-initial-app-mount