### PR TITLE
bug: bad url error message links to notehub

### DIFF
--- a/src/routes/Dashboard/Dashboard.svelte
+++ b/src/routes/Dashboard/Dashboard.svelte
@@ -26,6 +26,7 @@
   import { getHeatIndex, toFahrenheit, toCelsius } from "../../services/air";
   import { getReadings } from "../../services/device";
   import { shareDashboard } from "../../util/share";
+  import { APP_UID } from "../../constants";
   import { ERROR_TYPE } from "../../constants/ErrorTypes";
   import { renderErrorMessage } from "../../util/errors";
 
@@ -38,6 +39,8 @@
   let error = false;
   let errorType;
   let loading = true;
+
+  let eventsUrl = `https://notehub.io/project/${APP_UID}/events?queryMode=devices&queryDevices=${deviceUID}`;
 
   let tempDisplay = localStorage.getItem("tempDisplay") || "C";
   let showBanner =
@@ -131,7 +134,7 @@
   {/if}
 
   {#if error}
-    {@html renderErrorMessage(errorType)}
+    {@html renderErrorMessage(errorType, eventsUrl)}
   {/if}
 
   {#if lastReading}

--- a/src/routes/Settings/Settings.svelte
+++ b/src/routes/Settings/Settings.svelte
@@ -167,7 +167,7 @@
 </svelte:head>
 
 {#if error}
-  {@html renderErrorMessage(errorType)}
+  {@html renderErrorMessage(errorType, eventsUrl)}
 {/if}
 
 <section>
@@ -225,11 +225,12 @@
 <section>
   <p>
     <i>
-      By using your Airnote device, or completing the optional fields on this page, you
-      consent to openly sharing your device data and the optional contact information
-      under Creative Commons CC0. For the benefit of the community, all devices' data,
-      maps, dashboards, and contact information are openly published to the public.
-      If you do not wish your contact information to be published, please do not supply it.
+      By using your Airnote device, or completing the optional fields on this
+      page, you consent to openly sharing your device data and the optional
+      contact information under Creative Commons CC0. For the benefit of the
+      community, all devices' data, maps, dashboards, and contact information
+      are openly published to the public. If you do not wish your contact
+      information to be published, please do not supply it.
     </i>
   </p>
 </section>

--- a/src/util/errors.js
+++ b/src/util/errors.js
@@ -1,13 +1,13 @@
 import { ERROR_TYPE } from "../constants/ErrorTypes";
 
-export function renderErrorMessage(errorType) {
+export function renderErrorMessage(errorType, eventsUrl) {
   switch (true) {
     case errorType === ERROR_TYPE.NOTEHUB_ERROR:
       return `
         <div class="alert">
           <h4 class="alert-heading">Unable to fetch device details.</h4>
           Please make sure your Airnote is
-          <a href={eventsUrl} target="_new"> online and connected to Notehub.io </a>
+          <a href=${eventsUrl} target="_new"> online and connected to Notehub.io </a>
           before visiting this page. For help getting started, visit
           <a href="https://start.airnote.live" target="_new">
             start.airnote.live
@@ -52,7 +52,7 @@ export function renderErrorMessage(errorType) {
         <div class="alert">
           <h4 class="alert-heading">Unable to fetch device details.</h4>
           Please make sure your Airnote is
-          <a href={eventsUrl} target="_new"> online and connected to Notehub.io </a>
+          <a href=${eventsUrl} target="_new"> online and connected to Notehub.io </a>
           before visiting this page. For help getting started, visit
           <a href="https://start.airnote.live" target="_new">
             start.airnote.live


### PR DESCRIPTION
# Problem Context

While investigating an unrelated Airnote setup bug, I noticed the error message that are supposed to redirect users back to the Notehub Airnote project so they can check what events are being recorded by their device do not work. 

## Changes

Pass the `eventsUrl` link to Notehub to the error messages that need it and rewrite the HTML so it render the link correctly instead of trying to do an internal redirect within the project.

## Screenshot (if applicable)

Hovering over the `online and connected to Notehub.io` link produces the URL visible at the bottom of the browser window

<img width="1775" alt="Screen Shot 2022-11-14 at 10 34 18 AM" src="https://user-images.githubusercontent.com/20400845/201700920-694bf8f6-56e6-45b8-b7da-5064922d9c69.png">

## Testing

Unit / integration / e2e tests?
Steps to test manually?
Any other sorts of testing notes to include?

## Any other related PRs

n/a

## Ticket(s)

https://trello.com/c/SycH1Qk7/12-fix-bad-links-to-notehub-in-error-messages
