### PR TITLE
Update Notehub URLs to latest

### DIFF
--- a/src/routes/Settings/Settings.svelte
+++ b/src/routes/Settings/Settings.svelte
@@ -31,7 +31,7 @@
   let errorType;
   let notify;
 
-  let eventsUrl = `https://notehub.io/project/${APP_UID}/events?queryMode=devices&queryDevices=${deviceUID}`;
+  let eventsUrl = `https://notehub.io/project/${APP_UID}/events?queryDevice=${deviceUID}`;
 
   const displayOptions = [
     { value: "tempc", text: "Temp (°C)" },

--- a/src/util/errors.js
+++ b/src/util/errors.js
@@ -8,7 +8,7 @@ export function renderErrorMessage(errorType, deviceUID) {
         <div class="alert">
           <h4 class="alert-heading">Unable to fetch device details.</h4>
           Please make sure your Airnote is
-          <a href="https://notehub.io/project/${APP_UID}/events?queryMode=devices&queryDevices=${deviceUID}" target="_new"> online and connected to Notehub.io </a>
+          <a href="https://notehub.io/project/${APP_UID}/events?queryDevice=${deviceUID}" target="_new"> online and connected to Notehub.io </a>
           before visiting this page. For help getting started, visit
           <a href="https://start.airnote.live" target="_new">
             start.airnote.live
@@ -53,7 +53,7 @@ export function renderErrorMessage(errorType, deviceUID) {
         <div class="alert">
           <h4 class="alert-heading">Unable to fetch device details.</h4>
           Please make sure your Airnote is
-          <a href="https://notehub.io/project/${APP_UID}/events?queryMode=devices&queryDevices=${deviceUID}" target="_new"> online and connected to Notehub.io </a>
+          <a href="https://notehub.io/project/${APP_UID}/events?queryDevice=${deviceUID}" target="_new"> online and connected to Notehub.io </a>
           before visiting this page. For help getting started, visit
           <a href="https://start.airnote.live" target="_new">
             start.airnote.live


### PR DESCRIPTION
# Problem Context

## Changes
The links to Notehub are out-of-date. When clicking the link, it shows the events for all devices, not just the user's device.

## Testing

At the bottom of the settings page, click the link named "View live Airnote events on Notehub.io". If it's working correctly, it should show you Airnote events for just your Airnote.
