### PR TITLE
bug: adjust default reading frequency  

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -54,8 +54,27 @@ const getAirnoteEnvVars = (productUID, deviceUID, pin) => {
   );
 };
 
+// Delete the _air_mins environment variable from the device
+const deleteAirMinsEnvVar = (deviceUID) => {
+  return axios.delete(
+    `${NOTEHUB_BASE_URL}/v1/projects/${AIRNOTE_PROJECT_UID}/devices/${deviceUID}/environment_variables/_air_mins`,
+    { headers: HEADERS }
+  );
+};
+
 // update Airnote env vars by device with PIN - READ WRITE
-const updateAirnoteEnvVars = (productUID, deviceUID, pin, varsBody) => {
+const updateAirnoteEnvVars = async (productUID, deviceUID, pin, varsBody) => {
+  const varsBodyJSON = JSON.parse(varsBody);
+
+  // If the _air_mins environment variable is set to the default, don't save the value so
+  // the device defaults to the project-level _air_mins. Also, delete the environment variable
+  // on the device in case it already exists.
+  if (varsBodyJSON.environment_variables._air_mins.includes("high:30")) {
+    delete varsBodyJSON.environment_variables._air_mins;
+    await deleteAirMinsEnvVar(deviceUID);
+    varsBody = JSON.stringify(varsBodyJSON);
+  }
+
   return axios.put(
     `${NOTEHUB_BASE_URL}/v1/products/${productUID}/devices/${deviceUID}/environment_variables_with_pin`,
     varsBody,

--- a/src/routes/Home/Home.svelte
+++ b/src/routes/Home/Home.svelte
@@ -8,7 +8,7 @@
   <p>
     A global partnership between
     <a href="https://safecast.org" target="_new">Safecast</a> &amp;
-    <a href="https://blues.io" target="_net">Blues Wireless</a>. Powered by a
+    <a href="https://blues.io" target="_net">Blues</a>. Powered by a
     community of citizens monitoring the air we breathe.
   </p>
   <p>
@@ -29,7 +29,7 @@
   <p>
     To join the network, visit the
     <a href="https://shop.blues.io/products/airnote" target="new"
-      >Blues Wireless shop</a
+      >Blues shop</a
     > to purchase your own cellular-powered air quality monitoring device.
   </p>
 

--- a/src/routes/Settings/Settings.svelte
+++ b/src/routes/Settings/Settings.svelte
@@ -61,7 +61,7 @@
     return {
       environment_variables: {
         _sn: $deviceName,
-        _air_mins: `usb:${$sampleFrequencyUSB};high:${$sampleFrequencyFull};normal:${$sampleFrequencyFull};low:${$sampleFrequencyLow};0`,
+        _air_mins: `usb:${$sampleFrequencyUSB};high:${$sampleFrequencyFull};normal:${$sampleFrequencyFull};low:${$sampleFrequencyLow};43200`,
         _air_indoors: !!$indoorDevice ? "1" : "0",
         _air_status: $displayValue,
         _contact_name: $contactName,

--- a/src/routes/Settings/Slider.svelte
+++ b/src/routes/Settings/Slider.svelte
@@ -1,10 +1,10 @@
 <script>
-  import { onMount } from 'svelte';
-  import { sampleFrequencyFull } from '../../settingsStore';
+  import { onMount } from "svelte";
+  import { sampleFrequencyFull } from "../../settingsStore";
 
   export let enableFields;
 
-  sampleFrequencyFull.subscribe(value => {
+  sampleFrequencyFull.subscribe((value) => {
     const allRanges = document.querySelectorAll(".frequency-wrap");
     if (allRanges.length > 0) {
       const frequency = allRanges[0].querySelector("#sampleFrequency");
@@ -26,7 +26,7 @@
 
   onMount(() => {
     const allRanges = document.querySelectorAll(".frequency-wrap");
-    allRanges.forEach(wrap => {
+    allRanges.forEach((wrap) => {
       const frequency = wrap.querySelector("#sampleFrequency");
       const popup = wrap.querySelector(".frequencyPopup");
 
@@ -39,14 +39,17 @@
 </script>
 
 <div class="frequency-wrap">
-  <input type="range"
+  <input
+    type="range"
     name="frequency"
     id="sampleFrequency"
-    disabled={enableFields ? null : 'disabled'}
-    min="15" max="1440"
+    disabled={enableFields ? null : "disabled"}
+    min="15"
+    max="1440"
     bind:value={$sampleFrequencyFull}
-    step="5" />
-  <output class="frequencyPopup"></output>
+    step="5"
+  />
+  <output class="frequencyPopup" />
 </div>
 <span class="min-val">15 min</span>
 <span class="max-val">1440 min</span>
@@ -65,7 +68,7 @@
   }
 
   .frequencyPopup {
-    color: #1B3A52;
+    color: #1b3a52;
     font-weight: 600;
     padding: 4px 12px;
     position: absolute;
@@ -78,13 +81,14 @@
     position: absolute;
     width: 2px;
     height: 2px;
-    color: #1B3A52;
+    color: #1b3a52;
     top: 4px;
     right: 15%;
   }
 
-  .min-val, .max-val {
-    color: #A0AFB9;
+  .min-val,
+  .max-val {
+    color: #a0afb9;
   }
   .max-val {
     float: right;

--- a/src/settingsStore.js
+++ b/src/settingsStore.js
@@ -1,4 +1,4 @@
-import { writable } from 'svelte/store';
+import { writable } from "svelte/store";
 
 export const deviceName = writable("");
 export const displayValue = writable("");
@@ -9,4 +9,3 @@ export const sampleFrequencyLow = writable("720");
 export const contactName = writable("");
 export const contactEmail = writable("");
 export const contactAffiliation = writable("");
-


### PR DESCRIPTION
# Problem Context

A firmware change requires the `_air_mins` environment variable default settings to be updated.

## Changes

* Change the default settings for Airnote readings
* Add a check before sending new device env vars to Airnote device to delete env vars that would override project level env vars in Notehub. All other settings updates will go through as usual.

## Screenshot (if applicable)

## Testing

Unit / integration / e2e tests?
Steps to test manually?
Any other sorts of testing notes to include?

## Any other related PRs

n/a

## Ticket(s)

https://trello.com/c/4yyDtnlM/34-issue-with-airmins-environment-variable
