### PR TITLE
feat: add notehub events link to dashboard and move donate banner to bottom of page

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "install-svelte": "npm install",
     "setup": "npm run install-node & npm run install-svelte",
     "build": "rollup -c",
-    "dev": "npx concurrently --raw \"cd server && npx nodemon server.js\" \"rollup -c -w\"",
+    "dev": "npx -y concurrently --raw \"cd server && npx -y nodemon server.js\" \"rollup -c -w\"",
     "start": "sirv public --single --port 5555",
     "test": "jest",
     "test:watch": "npm run test -- --watch",

--- a/src/routes/Dashboard/Dashboard.svelte
+++ b/src/routes/Dashboard/Dashboard.svelte
@@ -331,6 +331,21 @@
         <PMChart {readings} />
       </div>
     </div>
+
+    {#if showBanner}
+      <div class="banner" in:fade>
+        <p>
+          The Airnote is made in partnership with
+          <a href="https://safecast.org/">Safecast</a>, a volunteer-centered
+          organization devoted to open citizen science for environmental
+          monitoring.
+          <a href="https://safecast.org/donate/">Donate here</a>.
+        </p>
+        <button class="svg-button" on:click={closeBanner}>
+          <CloseIcon />
+        </button>
+      </div>
+    {/if}
   {/if}
 </div>
 
@@ -389,20 +404,6 @@
       }}
     >
       Close
-    </button>
-  </div>
-{/if}
-
-{#if showBanner}
-  <div class="banner" in:fade>
-    <p>
-      The Airnote is made in partnership with
-      <a href="https://safecast.org/">Safecast</a>, a volunteer-centered
-      organization devoted to open citizen science for environmental monitoring.
-      <a href="https://safecast.org/donate/">Donate here</a>.
-    </p>
-    <button class="svg-button" on:click={closeBanner}>
-      <CloseIcon />
     </button>
   </div>
 {/if}

--- a/src/routes/Dashboard/Dashboard.svelte
+++ b/src/routes/Dashboard/Dashboard.svelte
@@ -20,6 +20,7 @@
   import HumidityChart from "../../components/charts/HumidityChart.svelte";
   import Recommendation from "./Recommendation.svelte";
   import Speedometer from "./Speedometer.svelte";
+  import { APP_UID } from "../../constants";
   import TOOLTIP_STATES from "../../constants/TooltipStates";
   import DATE_RANGE_OPTIONS from "../../constants/DateRangeOptions";
   import { convertDateRange, dateRangeDisplayText } from "../../util/dates";
@@ -44,6 +45,8 @@
     localStorage.getItem("showBanner") === "false" ? false : true;
   let tooltipState = TOOLTIP_STATES.CLOSED;
   let selectedDateRange = DATE_RANGE_OPTIONS.SEVEN_DAYS.displayText;
+
+  let eventsUrl = `https://notehub.io/project/${APP_UID}/events?queryDevice=${deviceUID}`;
 
   const toggleTempDisplay = () => {
     tempDisplay = tempDisplay == "C" ? "F" : "C";
@@ -135,26 +138,11 @@
   {/if}
 
   {#if lastReading}
-    {#if showBanner}
-      <div class="banner" in:fade>
-        <p>
-          The Airnote is made in partnership with
-          <a href="https://safecast.org/">Safecast</a>, a volunteer-centered
-          organization devoted to open citizen science for environmental
-          monitoring.
-          <a href="https://safecast.org/donate/">Donate here</a>.
-        </p>
-        <button class="svg-button" on:click={closeBanner}>
-          <CloseIcon />
-        </button>
-      </div>
-    {/if}
-
     <div class="air-quality-wrapper" in:fade>
       <h2 class="air-quality-heading" data-cy="dashboard-title">
         <span>
           Air Quality {lastReading.location ? "in " + lastReading.location : ""}
-          {lastReading.serial_number ? "—" + lastReading.serial_number : ""}
+          {lastReading.serial_number ? "— " + lastReading.serial_number : ""}
         </span>
       </h2>
 
@@ -287,6 +275,13 @@
           </div>
         </div>
       </div>
+
+      <p class="notehub-link">
+        <a href={eventsUrl} target="_new" data-cy="notehub-link">
+          View live Airnote events on Notehub.io
+        </a>
+      </p>
+
       <div class="map">
         <MapboxMap {lastReading} />
       </div>
@@ -398,6 +393,20 @@
   </div>
 {/if}
 
+{#if showBanner}
+  <div class="banner" in:fade>
+    <p>
+      The Airnote is made in partnership with
+      <a href="https://safecast.org/">Safecast</a>, a volunteer-centered
+      organization devoted to open citizen science for environmental monitoring.
+      <a href="https://safecast.org/donate/">Donate here</a>.
+    </p>
+    <button class="svg-button" on:click={closeBanner}>
+      <CloseIcon />
+    </button>
+  </div>
+{/if}
+
 <style>
   .dashboard {
     min-height: 200px;
@@ -449,11 +458,17 @@
       "title title"
       "last-update last-update"
       "speedometer all-measurements"
+      "notehub-link notehub-link"
       "map map";
   }
 
   .current-readings-title {
     grid-area: title;
+    margin-bottom: 0;
+  }
+
+  .notehub-link {
+    grid-area: notehub-link;
     margin-bottom: 0;
   }
 


### PR DESCRIPTION
# Problem Context

A couple of small additions to the Airnote dashboard: add the Notehub device events link already present on the settings page to the dashboard page, and adjust the placement of the Safecast donation banner. 

## Changes

* Add existing Notehub.io link from the settings page to the dashboard page and insert it underneath the AQI readings and above the map
* Move the "Donate to Safecast" banner from the top of the dashboard page to the bottom of the dashboard
* Add `-y` to scripts to run a local version of the app for development to prevent having to agree to install `concurrently` and `nodemon` each time the app starts up

## Screenshot (if applicable)

![Screenshot 2023-09-08 at 1 41 11 PM](https://github.com/blues/airnote.live/assets/20400845/ffea92c7-13fa-4d07-9c07-94a345257a1d)

![Screenshot 2023-09-08 at 2 08 34 PM](https://github.com/blues/airnote.live/assets/20400845/0509307a-cdc6-4ac1-bb44-401700e7643b)

## Testing

Unit / integration / e2e tests?
Steps to test manually?
Any other sorts of testing notes to include?

## Any other related PRs

## Ticket(s)

* https://trello.com/c/w0OZxbDH/21-airnote-dashboard-surface-a-notehubio-events-link-from-the-dashboard
* https://trello.com/c/LQnrm1GT/13-move-the-donate-pop-up-to-the-bottom-of-the-screen-above-the-footer
