### PR TITLE
feat: move dns from render to netlify

### DIFF
--- a/ops/.gitignore
+++ b/ops/.gitignore
@@ -1,0 +1,1 @@
+.terraform

--- a/ops/.terraform.lock.hcl
+++ b/ops/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.67.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:5Zfo3GfRSWBaXs4TGQNOflr1XaYj6pRnVJLX5VAjFX4=",
+    "h1:dCRc4GqsyfqHEMjgtlM1EympBcgTmcTkWaJmtd91+KA=",
+    "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
+    "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",
+    "zh:24995686b2ad88c1ffaa242e36eee791fc6070e6144f418048c4ce24d0ba5183",
+    "zh:4a002990b9f4d6d225d82cb2fb8805789ffef791999ee5d9cb1fef579aeff8f1",
+    "zh:559a2b5ace06b878c6de3ecf19b94fbae3512562f7a51e930674b16c2f606e29",
+    "zh:6a07da13b86b9753b95d4d8218f6dae874cf34699bca1470d6effbb4dee7f4b7",
+    "zh:768b3bfd126c3b77dc975c7c0e5db3207e4f9997cf41aa3385c63206242ba043",
+    "zh:7be5177e698d4b547083cc738b977742d70ed68487ce6f49ecd0c94dbf9d1362",
+    "zh:8b562a818915fb0d85959257095251a05c76f3467caa3ba95c583ba5fe043f9b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c385d03a958b54e2afd5279cd8c7cbdd2d6ca5c7d6a333e61092331f38af7cf",
+    "zh:b3ca45f2821a89af417787df8289cb4314b273d29555ad3b2a5ab98bb4816b3b",
+    "zh:da3c317f1db2469615ab40aa6baba63b5643bae7110ff855277a1fb9d8eb4f2c",
+    "zh:dc6430622a8dc5cdab359a8704aec81d3825ea1d305bbb3bbd032b1c6adfae0c",
+    "zh:fac0d2ddeadf9ec53da87922f666e1e73a603a611c57bcbc4b86ac2821619b1d",
+  ]
+}

--- a/ops/README.md
+++ b/ops/README.md
@@ -1,0 +1,45 @@
+# Netlify Ops
+
+## Terraform
+
+The infrastructure is defined using Terraform, a tool for building, changing,
+and versioning infrastructure safely and efficiently.
+
+### prod.tf
+
+The code defines the required provider for AWS and sets up the backend for
+storing the Terraform state file in an S3 bucket.
+
+It also defines a Route53 zone for the domain "airnote.live" and creates three
+Route53 records:
+
+1. An A record for the root domain "airnote.live" that points to the IP address
+   "75.2.60.5".
+2. A CNAME record for the subdomain "start.airnote.live" that points to the
+   domain "airnote-live.netlify.app".
+3. A CNAME record for the subdomain "www.airnote.live" that points to the domain
+   "airnote-live.netlify.app".
+
+### Once ever
+
+(Carl already did this)
+
+- Manually create the S3 bucket (private and versioned) for storing the
+  Terraform state.
+
+### Once on your machine
+
+Install terraform 1.4.6 from the terraform website. (Simple portable binary, no 'install' needed)
+
+```bash
+aws configure --profile blues-prod # set up aws creds blues-prod
+```
+
+### After each change of the Terraform code
+
+To apply the Terraform code, run the following commands:
+
+```bash
+terraform init
+terraform apply
+```

--- a/ops/prod.tf
+++ b/ops/prod.tf
@@ -1,0 +1,53 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+  backend "s3" {
+    bucket  = "airnote-live-terraform-state"
+    key     = "airnote-live-state"
+    region  = "us-east-1"
+    encrypt = true
+    profile = "blues-prod"
+  }
+}
+
+provider "aws" {
+  alias   = "prod"
+  region  = "us-east-1"
+  profile = "blues-prod"
+}
+
+data "aws_route53_zone" "airnote-live" {
+  provider     = aws.prod
+  name         = "airnote.live"
+}
+
+resource "aws_route53_record" "a_airnote_live" {
+  provider = aws.prod
+  name    = "airnote.live"
+  type    = "A"
+  records = ["75.2.60.5"]
+  ttl     = 300
+  zone_id = data.aws_route53_zone.airnote-live.zone_id
+}
+
+resource "aws_route53_record" "cname_start_airnote_live" {
+  provider = aws.prod
+  name    = "start.airnote.live"
+  type    = "CNAME"
+  records = ["airnote-live.netlify.app"]
+  ttl     = 300
+  zone_id = data.aws_route53_zone.airnote-live.zone_id
+}
+
+resource "aws_route53_record" "cname_www_airnote_live" {
+  provider = aws.prod
+  name    = "www.airnote.live"
+  type    = "CNAME"
+  records = ["airnote-live.netlify.app"]
+  ttl     = 300
+  zone_id = data.aws_route53_zone.airnote-live.zone_id
+}


### PR DESCRIPTION
# Problem Context

DNS for airnote.live start.airnote.live and www.airnote.live were pointing to render.com but we are moving to netlify.com as a web host. 

## Changes

Create terraform IaC for netlify web site dns. (dmarc records are managed elsewhere)

## Screenshot (if applicable)
```
16:48 $ terraform plan
data.aws_route53_zone.airnote-live: Reading...
data.aws_route53_zone.airnote-live: Read complete after 1s [id=Z10280582OPRPH0SJWCVB]
aws_route53_record.cname_www_airnote_live: Refreshing state... [id=Z10280582OPRPH0SJWCVB_www.airnote.live_CNAME]
aws_route53_record.a_airnote_live: Refreshing state... [id=Z10280582OPRPH0SJWCVB_airnote.live_A]
aws_route53_record.cname_start_airnote_live: Refreshing state... [id=Z10280582OPRPH0SJWCVB_start.airnote.live_CNAME]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```


## Testing

Steps to test manually?
- TJ and Paige will be testing this over the coming days.

## Any other related PRs

The move to netlify is happening at the same time as the move to svelt in #54 

## Ticket(s)

https://trello.com/c/SzNcZSkk/515-airnotelive-dns-for-netlify