### PR TITLE
fix: handle for Notehub sending URL encoded DeviceUIDs

### DIFF
--- a/src/lib/services/device.ts
+++ b/src/lib/services/device.ts
@@ -4,7 +4,7 @@ import queryString from 'query-string';
 import type { AirnoteReading } from '$lib/services/AirReadingModel';
 import type { NotehubEvent } from '$lib/services/NotehubEventModel';
 import type { AirnoteDevice } from '$lib/services/DeviceModel';
-import type { DeviceDisplayOption } from '$lib/services/DeviceDisplayModel';
+import { getPathname } from '$lib/util/url';
 
 export function getHistoryReadings(readings: AirnoteReading[]) {
   // Group the readings into the calendar day they occurred on
@@ -95,7 +95,7 @@ export function getCurrentDeviceFromUrl(location: Location) {
   const query = queryString.parse(location.search);
   let pin = query['pin'] || '';
   let productUID = query['product'] || AIRNOTE_PRODUCT_UID;
-  let deviceUID = location.pathname.match(/dev:\d*/)?.[0] || '';
+  let deviceUID = getPathname().match(/dev:\d*/)?.[0] || '';
   const internalNav = query['internalNav'];
 
   // If there is no device in the query string default to the

--- a/src/lib/util/url.ts
+++ b/src/lib/util/url.ts
@@ -1,0 +1,5 @@
+// The “Dashboard” link in Notehub links to the Airnote site with
+// a DeviceUID in the format dev%3abcdef.
+export function getPathname() {
+  return decodeURIComponent(location.pathname);
+}

--- a/src/routes/[deviceUID]/+page.svelte
+++ b/src/routes/[deviceUID]/+page.svelte
@@ -23,6 +23,7 @@
   } from '$lib/services/DeviceModel';
   import { ERROR_TYPE } from '$lib/constants/ErrorTypes';
   import { renderErrorMessage } from '$lib/util/errors';
+  import { getPathname } from '$lib/util/url';
 
   export let pin: PotentiallyNullDeviceDetails = '';
   export let deviceUID: string = '';
@@ -146,7 +147,7 @@
     settings page when first directed there from Notehub. */
     if (
       deviceUID &&
-      location.pathname === '/' + deviceUID &&
+      getPathname() === '/' + deviceUID &&
       !pin &&
       internalNav === 'false'
     ) {


### PR DESCRIPTION
# Problem Context

If you use Notehub’s “Dashboard” link you end up going to a URL like `https://airnote.live/dev%3A864475044221348?product=product%3Aorg.airnote.solar.air.v1&pin=`. This caused problems with our redirect logic because the DeviceUID is URL encoded.

## Changes

This PR adds a new utility function that decodes the pathname.

## Testing

Open this URL in a private window and ensure it redirects `http://localhost:5173/dev%3A864475044221348?product=product%3Aorg.airnote.solar.air.v1&pin=`. Browse around a little and make sure normal navigation works as expected.
