### PR TITLE
chore: move mapbox api key into env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ HUB_AUTH_TOKEN=<your token>
 
 You can refer to [the Notehub API’s authentication documentation](https://dev.blues.io/reference/notehub-api/api-introduction/#authentication) for steps on how to generate your own token.
 
+It also uses a Mapbox API token to display the device's location on a map on the dashboard page. This token can also be added to the `.env` file, under the name listed below.
+
+You can create your own Mapbox API token by [signing up for a free Mapbox account](https://account.mapbox.com/auth/signin/?route-to=%22https%3A%2F%2Faccount.mapbox.com%2F%22) and following these [instructions to create an access token](https://docs.mapbox.com/help/glossary/access-token/).
+
+```plaintext
+PUBLIC_MAPBOX_TOKEN=<your mapbox token>
+```
+
 ## Testing
 
 ### Unit Testing

--- a/src/routes/[deviceUID]/dashboard/MapboxMap.svelte
+++ b/src/routes/[deviceUID]/dashboard/MapboxMap.svelte
@@ -5,6 +5,7 @@
   import { DATE_TIME_KEY } from '$lib/constants';
   import mapboxgl from 'mapbox-gl';
   import type { AirnoteReading } from '$lib/services/AirReadingModel';
+  import { PUBLIC_MAPBOX_TOKEN } from '$env/static/public';
 
   export let lastReading: AirnoteReading;
 
@@ -13,8 +14,7 @@
   let markerColor;
   let zoom = 10;
   let popup;
-  let mapboxToken =
-    'pk.eyJ1IjoicGFpZ2VuMTEiLCJhIjoiY2lyemJlZ3A0MDBqZTJ5cGs5ZHJicjI2YyJ9.2-dZqM-k2obDN47BpWq5Lw';
+  let mapboxToken = PUBLIC_MAPBOX_TOKEN;
 
   onMount(() => {
     mapboxgl.accessToken = mapboxToken;


### PR DESCRIPTION
# Problem Context

Now that we’re using Netlify to host our Airnote dashboards, we should create a new Mapbox API token (and deactivate the old one) and move it out of the project and into a Netlify secret env vars.

It’s not a critical secret API key, but it’d be much better to have it out of the public domain in keeping with best practices.

## Changes

* Make the Mapbox token an env var that gets imported into the `MapboxMap.svelte` file instead of hardcoding it straight into that file.

## Screenshot (if applicable)

New env var in Netlify

![Screenshot 2023-11-10 at 5 00 14 PM](https://github.com/blues/airnote.live/assets/20400845/e3a156d7-0fa5-4977-b724-366b48d3e096)

## Testing

Unit / integration / e2e tests?

Tests pass 

Steps to test manually?
Any other sorts of testing notes to include?

## Any other related PRs

n/a

## Ticket(s)

https://trello.com/c/Zpbc4GNv/53-move-mapbox-api-token-to-netlify-protected-env-var
