### PR TITLE
feat: increase historical data limits for device dashboards

### DIFF
--- a/cypress/e2e/airnote-pages.spec.cy.ts
+++ b/cypress/e2e/airnote-pages.spec.cy.ts
@@ -92,9 +92,9 @@ describe('Airnote application', () => {
     cy.get('[data-cy="history-heading"]').should('be.visible');
     // check date range dropdown is visible and defaults to "Last 7 Days"
     cy.get('[data-cy="chart-date-selector"').should('contain', 'Last 7 Days');
-    cy.get('[data-cy="chart-date-selector"').select('Last 5 Days');
-    // check date range dropdown is visible and updates to "Last 5 Days"
-    cy.get('[data-cy="chart-date-selector"').should('contain', 'Last 5 Days');
+    cy.get('[data-cy="chart-date-selector"').select('Last 30 Days');
+    // check date range dropdown is visible and updates to "Last 30 Days"
+    cy.get('[data-cy="chart-date-selector"').should('contain', 'Last 30 Days');
     // check charts
     cy.get('[data-cy="voltage-chart"]').should('be.visible');
     cy.get('[data-cy="temperature-chart"]').should('be.visible');

--- a/src/lib/components/charts/AQIChart.svelte
+++ b/src/lib/components/charts/AQIChart.svelte
@@ -80,14 +80,3 @@
 <div class="chart-container">
   <canvas id="aqiChart" bind:this={ctx} data-cy="aqi-chart" />
 </div>
-
-<style>
-  /* chart container div with relative positioning and `maintainAspectRatio: false 
-  option required to update the canvas render and display sizes for responsiveness: 
-  https://www.chartjs.org/docs/latest/configuration/responsive.html#important-note */
-  .chart-container {
-    position: relative;
-    min-height: 300px;
-    aspect-ratio: 1.4;
-  }
-</style>

--- a/src/lib/components/charts/AQIChart.svelte
+++ b/src/lib/components/charts/AQIChart.svelte
@@ -49,6 +49,7 @@
   };
 
   const options: ChartOptions<'line'> = {
+    maintainAspectRatio: false,
     scales: {
       x: {
         ticks: {
@@ -76,10 +77,17 @@
   });
 </script>
 
-<canvas
-  id="aqiChart"
-  bind:this={ctx}
-  width={420}
-  height={300}
-  data-cy="aqi-chart"
-/>
+<div class="chart-container">
+  <canvas id="aqiChart" bind:this={ctx} data-cy="aqi-chart" />
+</div>
+
+<style>
+  /* chart container div with relative positioning and `maintainAspectRatio: false 
+  option required to update the canvas render and display sizes for responsiveness: 
+  https://www.chartjs.org/docs/latest/configuration/responsive.html#important-note */
+  .chart-container {
+    position: relative;
+    min-height: 300px;
+    aspect-ratio: 1.4;
+  }
+</style>

--- a/src/lib/components/charts/HumidityChart.svelte
+++ b/src/lib/components/charts/HumidityChart.svelte
@@ -24,7 +24,9 @@
       const d = parseISO(reading.captured);
       return {
         x: format(d, DATE_TIME_FORMAT_KEY),
-        y: parseFloat(reading.humidity.toString()).toFixed(2)
+        y: reading.humidity
+          ? parseFloat(reading.humidity.toString()).toFixed(2)
+          : 0.0
       };
     });
   }

--- a/src/lib/components/charts/HumidityChart.svelte
+++ b/src/lib/components/charts/HumidityChart.svelte
@@ -51,6 +51,7 @@
   };
 
   const options: ChartOptions<'line'> = {
+    maintainAspectRatio: false,
     scales: {
       x: {
         ticks: {
@@ -78,10 +79,17 @@
   });
 </script>
 
-<canvas
-  id="humdityChart"
-  bind:this={ctx}
-  width={420}
-  height={300}
-  data-cy="humidity-chart"
-/>
+<div class="chart-container">
+  <canvas id="humdityChart" bind:this={ctx} data-cy="humidity-chart" />
+</div>
+
+<style>
+  /* chart container div with relative positioning and `maintainAspectRatio: false 
+  option required to update the canvas render and display sizes for responsiveness: 
+  https://www.chartjs.org/docs/latest/configuration/responsive.html#important-note */
+  .chart-container {
+    position: relative;
+    min-height: 300px;
+    aspect-ratio: 1.4;
+  }
+</style>

--- a/src/lib/components/charts/HumidityChart.svelte
+++ b/src/lib/components/charts/HumidityChart.svelte
@@ -82,14 +82,3 @@
 <div class="chart-container">
   <canvas id="humdityChart" bind:this={ctx} data-cy="humidity-chart" />
 </div>
-
-<style>
-  /* chart container div with relative positioning and `maintainAspectRatio: false 
-  option required to update the canvas render and display sizes for responsiveness: 
-  https://www.chartjs.org/docs/latest/configuration/responsive.html#important-note */
-  .chart-container {
-    position: relative;
-    min-height: 300px;
-    aspect-ratio: 1.4;
-  }
-</style>

--- a/src/lib/components/charts/PMChart.svelte
+++ b/src/lib/components/charts/PMChart.svelte
@@ -123,14 +123,3 @@
 <div class="chart-container">
   <canvas id="pmChart" bind:this={ctx} data-cy="pm-chart" />
 </div>
-
-<style>
-  /* chart container div with relative positioning and `maintainAspectRatio: false 
-  option required to update the canvas render and display sizes for responsiveness: 
-  https://www.chartjs.org/docs/latest/configuration/responsive.html#important-note */
-  .chart-container {
-    position: relative;
-    min-height: 300px;
-    aspect-ratio: 1.4;
-  }
-</style>

--- a/src/lib/components/charts/PMChart.svelte
+++ b/src/lib/components/charts/PMChart.svelte
@@ -30,21 +30,27 @@
       const d = parseISO(reading.captured);
       return {
         x: format(d, DATE_TIME_FORMAT_KEY),
-        y: parseFloat(reading.pm01_0.toString()).toFixed(2)
+        y: reading.pm01_0
+          ? parseFloat(reading.pm01_0.toString()).toFixed(2)
+          : 0.0
       };
     });
     pm2_5Data = readings.map((reading) => {
       const d = parseISO(reading.captured);
       return {
         x: format(d, DATE_TIME_FORMAT_KEY),
-        y: parseFloat(reading.pm02_5.toString()).toFixed(2)
+        y: reading.pm02_5
+          ? parseFloat(reading.pm02_5.toString()).toFixed(2)
+          : 0.0
       };
     });
     pm10Data = readings.map((reading) => {
       const d = parseISO(reading.captured);
       return {
         x: format(d, DATE_TIME_FORMAT_KEY),
-        y: parseFloat(reading.pm10_0.toString()).toFixed(2)
+        y: reading.pm10_0
+          ? parseFloat(reading.pm10_0.toString()).toFixed(2)
+          : 0.0
       };
     });
   }

--- a/src/lib/components/charts/PMChart.svelte
+++ b/src/lib/components/charts/PMChart.svelte
@@ -92,6 +92,7 @@
   };
 
   const options: ChartOptions<'line'> = {
+    maintainAspectRatio: false,
     scales: {
       x: {
         ticks: {
@@ -119,10 +120,17 @@
   });
 </script>
 
-<canvas
-  id="pmChart"
-  bind:this={ctx}
-  width={420}
-  height={300}
-  data-cy="pm-chart"
-/>
+<div class="chart-container">
+  <canvas id="pmChart" bind:this={ctx} data-cy="pm-chart" />
+</div>
+
+<style>
+  /* chart container div with relative positioning and `maintainAspectRatio: false 
+  option required to update the canvas render and display sizes for responsiveness: 
+  https://www.chartjs.org/docs/latest/configuration/responsive.html#important-note */
+  .chart-container {
+    position: relative;
+    min-height: 300px;
+    aspect-ratio: 1.4;
+  }
+</style>

--- a/src/lib/components/charts/TempChart.svelte
+++ b/src/lib/components/charts/TempChart.svelte
@@ -131,15 +131,6 @@
 </div>
 
 <style>
-  /* chart container div with relative positioning and `maintainAspectRatio: false 
-  option required to update the canvas render and display sizes for responsiveness: 
-  https://www.chartjs.org/docs/latest/configuration/responsive.html#important-note */
-  .chart-container {
-    position: relative;
-    min-height: 300px;
-    aspect-ratio: 1.4;
-  }
-
   .button-group {
     margin-top: 0.5rem;
   }

--- a/src/lib/components/charts/TempChart.svelte
+++ b/src/lib/components/charts/TempChart.svelte
@@ -29,14 +29,18 @@
       const d = parseISO(reading.captured);
       return {
         x: format(d, DATE_TIME_FORMAT_KEY),
-        y: parseFloat(reading.temperature.toString()).toFixed(2)
+        y: reading.temperature
+          ? parseFloat(reading.temperature.toString()).toFixed(2)
+          : 0.0
       };
     });
     tempDataFahrenheit = readings.map((reading) => {
       const d = parseISO(reading.captured);
       return {
         x: format(d, DATE_TIME_FORMAT_KEY),
-        y: parseFloat(toFahrenheit(reading.temperature).toString()).toFixed(2)
+        y: reading.temperature
+          ? parseFloat(toFahrenheit(reading.temperature).toString()).toFixed(2)
+          : 0.0
       };
     });
   }

--- a/src/lib/components/charts/TempChart.svelte
+++ b/src/lib/components/charts/TempChart.svelte
@@ -93,6 +93,7 @@
   };
 
   const options: ChartOptions<'line'> = {
+    maintainAspectRatio: false,
     scales: {
       x: {
         ticks: {
@@ -120,13 +121,9 @@
   });
 </script>
 
-<canvas
-  id="temperatureChart"
-  bind:this={ctx}
-  width={420}
-  height={300}
-  data-cy="temperature-chart"
-/>
+<div class="chart-container">
+  <canvas id="temperatureChart" bind:this={ctx} data-cy="temperature-chart" />
+</div>
 <div class="button-group">
   <button on:click={() => fetchTempChartDisplay(tempDisplay)}>
     Change to °{tempDisplay == 'C' ? 'F' : 'C'}
@@ -134,6 +131,15 @@
 </div>
 
 <style>
+  /* chart container div with relative positioning and `maintainAspectRatio: false 
+  option required to update the canvas render and display sizes for responsiveness: 
+  https://www.chartjs.org/docs/latest/configuration/responsive.html#important-note */
+  .chart-container {
+    position: relative;
+    min-height: 300px;
+    aspect-ratio: 1.4;
+  }
+
   .button-group {
     margin-top: 0.5rem;
   }

--- a/src/lib/components/charts/VoltageChart.svelte
+++ b/src/lib/components/charts/VoltageChart.svelte
@@ -30,7 +30,9 @@
       const d = parseISO(reading.captured);
       return {
         x: format(d, DATE_TIME_FORMAT_KEY),
-        y: parseFloat(reading.voltage.toString()).toFixed(2)
+        y: reading.voltage
+          ? parseFloat(reading.voltage.toString()).toFixed(2)
+          : 0.0
       };
     });
     chargingData = readings

--- a/src/lib/components/charts/VoltageChart.svelte
+++ b/src/lib/components/charts/VoltageChart.svelte
@@ -76,6 +76,7 @@
   };
 
   const options: ChartOptions<'line'> = {
+    maintainAspectRatio: false,
     scales: {
       x: {
         ticks: {
@@ -126,10 +127,17 @@
   });
 </script>
 
-<canvas
-  id="voltageChart"
-  bind:this={ctx}
-  width={420}
-  height={300}
-  data-cy="voltage-chart"
-/>
+<div class="chart-container">
+  <canvas id="voltageChart" bind:this={ctx} data-cy="voltage-chart" />
+</div>
+
+<style>
+  /* chart container div with relative positioning and `maintainAspectRatio: false 
+  option required to update the canvas render and display sizes for responsiveness: 
+  https://www.chartjs.org/docs/latest/configuration/responsive.html#important-note */
+  .chart-container {
+    position: relative;
+    min-height: 300px;
+    aspect-ratio: 1.4;
+  }
+</style>

--- a/src/lib/components/charts/VoltageChart.svelte
+++ b/src/lib/components/charts/VoltageChart.svelte
@@ -130,14 +130,3 @@
 <div class="chart-container">
   <canvas id="voltageChart" bind:this={ctx} data-cy="voltage-chart" />
 </div>
-
-<style>
-  /* chart container div with relative positioning and `maintainAspectRatio: false 
-  option required to update the canvas render and display sizes for responsiveness: 
-  https://www.chartjs.org/docs/latest/configuration/responsive.html#important-note */
-  .chart-container {
-    position: relative;
-    min-height: 300px;
-    aspect-ratio: 1.4;
-  }
-</style>

--- a/src/lib/constants/DateRangeOptions.ts
+++ b/src/lib/constants/DateRangeOptions.ts
@@ -5,9 +5,5 @@ export default {
   FIVE_DAYS: { displayText: 'Last 5 Days', daysPrior: 5 },
   SEVEN_DAYS: { displayText: 'Last 7 Days', daysPrior: 7 },
   FIFTEEN_DAYS: { displayText: 'Last 15 Days', daysPrior: 15 },
-  THIRTY_DAYS: { displayText: 'Last 30 Days', daysPrior: 30 },
-  FORTY_FIVE_DAYS: { displayText: 'Last 45 Days', daysPrior: 45 },
-  SIXTY_DAYS: { displayText: 'Last 60 Days', daysPrior: 60 },
-  SEVENTY_FIVE_DAYS: { displayText: 'Last 75 Days', daysPrior: 75 },
-  NINETY_DAYS: { displayText: 'Last 90 Days', daysPrior: 90 }
+  THIRTY_DAYS: { displayText: 'Last 30 Days', daysPrior: 30 }
 };

--- a/src/lib/constants/DateRangeOptions.ts
+++ b/src/lib/constants/DateRangeOptions.ts
@@ -3,5 +3,11 @@ export default {
   TWO_DAYS: { displayText: 'Last 2 Days', daysPrior: 2 },
   THREE_DAYS: { displayText: 'Last 3 Days', daysPrior: 3 },
   FIVE_DAYS: { displayText: 'Last 5 Days', daysPrior: 5 },
-  SEVEN_DAYS: { displayText: 'Last 7 Days', daysPrior: 7 }
+  SEVEN_DAYS: { displayText: 'Last 7 Days', daysPrior: 7 },
+  FIFTEEN_DAYS: { displayText: 'Last 15 Days', daysPrior: 15 },
+  THIRTY_DAYS: { displayText: 'Last 30 Days', daysPrior: 30 },
+  FORTY_FIVE_DAYS: { displayText: 'Last 45 Days', daysPrior: 45 },
+  SIXTY_DAYS: { displayText: 'Last 60 Days', daysPrior: 60 },
+  SEVENTY_FIVE_DAYS: { displayText: 'Last 75 Days', daysPrior: 75 },
+  NINETY_DAYS: { displayText: 'Last 90 Days', daysPrior: 90 }
 };

--- a/src/lib/constants/DateRangeOptions.ts
+++ b/src/lib/constants/DateRangeOptions.ts
@@ -1,9 +1,6 @@
 export default {
   ONE_DAY: { displayText: 'Last Day', daysPrior: 1 },
-  TWO_DAYS: { displayText: 'Last 2 Days', daysPrior: 2 },
-  THREE_DAYS: { displayText: 'Last 3 Days', daysPrior: 3 },
-  FIVE_DAYS: { displayText: 'Last 5 Days', daysPrior: 5 },
   SEVEN_DAYS: { displayText: 'Last 7 Days', daysPrior: 7 },
-  FIFTEEN_DAYS: { displayText: 'Last 15 Days', daysPrior: 15 },
+  FOURTEEN_DAYS: { displayText: 'Last 14 Days', daysPrior: 14 },
   THIRTY_DAYS: { displayText: 'Last 30 Days', daysPrior: 30 }
 };

--- a/src/lib/services/device.ts
+++ b/src/lib/services/device.ts
@@ -95,7 +95,12 @@ export function getCurrentDeviceFromUrl(location: Location) {
   const query = queryString.parse(location.search);
   let pin = query['pin'] || '';
   let productUID = query['product'] || AIRNOTE_PRODUCT_UID;
-  let deviceUID = getPathname().match(/dev:\d*/)?.[0] || '';
+  // check if the pathname has a % in it which means it needs to be decoded, if so, decode it
+  // if not, continue on (this is as much to fix broken unit tests as anything else)
+  const sanitizedPathname = location.pathname.includes('%')
+    ? getPathname()
+    : location.pathname;
+  let deviceUID = sanitizedPathname.match(/dev:\d*/)?.[0] || '';
   const internalNav = query['internalNav'];
 
   // If there is no device in the query string default to the

--- a/src/lib/services/notehub.ts
+++ b/src/lib/services/notehub.ts
@@ -83,17 +83,17 @@ export async function updateDeviceEnvironmentVariablesByPin(
 
 // get events from Airnote project in Notehub
 export async function getEvents(deviceUID: string) {
-  /* this function is originally fetched on mount with 90 days' worth of data to
+  /* this function is originally fetched on mount with 30 days' worth of data to
 		  populate the AQI average history with the previous week's data AND
 		  display today's most current reading as well */
-  const TIMEFRAME = '90 days';
+  const TIMEFRAME = '30 days';
 
   const body = {
     req: 'hub.app.data.query',
     query: {
       columns:
         ".body;.when;lat:(events.value->'best_lat');lon:(events.value->'best_lon');location:(events.value->'best_location')",
-      limit: 12000,
+      limit: 4000,
       order: '.modified',
       descending: true,
       where: `.file::text='_air.qo' and .device::text='${deviceUID}' and .modified >= now()-interval '${TIMEFRAME}'`

--- a/src/lib/services/notehub.ts
+++ b/src/lib/services/notehub.ts
@@ -93,7 +93,7 @@ export async function getEvents(deviceUID: string) {
     query: {
       columns:
         ".body;.when;lat:(events.value->'best_lat');lon:(events.value->'best_lon');location:(events.value->'best_location')",
-      limit: 15000,
+      limit: 12000,
       order: '.modified',
       descending: true,
       where: `.file::text='_air.qo' and .device::text='${deviceUID}' and .modified >= now()-interval '${TIMEFRAME}'`

--- a/src/lib/services/notehub.ts
+++ b/src/lib/services/notehub.ts
@@ -83,17 +83,17 @@ export async function updateDeviceEnvironmentVariablesByPin(
 
 // get events from Airnote project in Notehub
 export async function getEvents(deviceUID: string) {
-  /* this function is originally fetched on mount with 30 days' worth of data to
-		  populate the AQI average history with the previous week's data AND
+  /* this function is fetched on mount with 90 days' worth of data to
+		  populate the CSV download, the AQI average history AND
 		  display today's most current reading as well */
-  const TIMEFRAME = '30 days';
+  const TIMEFRAME = '90 days';
 
   const body = {
     req: 'hub.app.data.query',
     query: {
       columns:
         ".body;.when;lat:(events.value->'best_lat');lon:(events.value->'best_lon');location:(events.value->'best_location')",
-      limit: 4000,
+      limit: 12000,
       order: '.modified',
       descending: true,
       where: `.file::text='_air.qo' and .device::text='${deviceUID}' and .modified >= now()-interval '${TIMEFRAME}'`

--- a/src/lib/services/notehub.ts
+++ b/src/lib/services/notehub.ts
@@ -83,17 +83,17 @@ export async function updateDeviceEnvironmentVariablesByPin(
 
 // get events from Airnote project in Notehub
 export async function getEvents(deviceUID: string) {
-  /* this function is originally fetched on mount with 8 days' worth of data to
+  /* this function is originally fetched on mount with 90 days' worth of data to
 		  populate the AQI average history with the previous week's data AND
 		  display today's most current reading as well */
-  const TIMEFRAME = '8 days';
+  const TIMEFRAME = '90 days';
 
   const body = {
     req: 'hub.app.data.query',
     query: {
       columns:
         ".body;.when;lat:(events.value->'best_lat');lon:(events.value->'best_lon');location:(events.value->'best_location')",
-      limit: 1000,
+      limit: 15000,
       order: '.modified',
       descending: true,
       where: `.file::text='_air.qo' and .device::text='${deviceUID}' and .modified >= now()-interval '${TIMEFRAME}'`

--- a/src/lib/services/notehub.ts
+++ b/src/lib/services/notehub.ts
@@ -83,10 +83,10 @@ export async function updateDeviceEnvironmentVariablesByPin(
 
 // get events from Airnote project in Notehub
 export async function getEvents(deviceUID: string) {
-  /* this function is fetched on mount with 90 days' worth of data to
+  /* this function is fetched on mount with 30 days' worth of data to
 		  populate the CSV download, the AQI average history AND
 		  display today's most current reading as well */
-  const TIMEFRAME = '90 days';
+  const TIMEFRAME = '30 days';
 
   const body = {
     req: 'hub.app.data.query',

--- a/src/routes/[deviceUID]/dashboard/+page.svelte
+++ b/src/routes/[deviceUID]/dashboard/+page.svelte
@@ -56,6 +56,9 @@
   $: if (deviceUID) {
     eventsUrl = `https://notehub.io/project/${APP_UID}/events?queryDevice=${deviceUID}`;
   }
+
+  let expandCharts: boolean = false;
+
   // data fetched from Notehub API via +page.server.ts on page load
   export let data;
 
@@ -82,7 +85,16 @@
   $: if (selectedDateRange) {
     const convertedTimeframe = convertDateRange(selectedDateRange);
     displayedReadings = filterEventsByDate(readings, convertedTimeframe);
+    // if the selected date range is 30 days, expand the smaller charts to full width
+    if (selectedDateRange === DATE_RANGE_OPTIONS.THIRTY_DAYS.displayText) {
+      expandCharts = true;
+    } else {
+      expandCharts = false;
+    }
   }
+
+  $: chartLayout = expandCharts ? 'large-charts' : 'charts';
+  $: chartWidth = expandCharts ? 'maximize-chart' : '';
 
   const toggleTempDisplay = () => {
     tempDisplay = tempDisplay == 'C' ? 'F' : 'C';
@@ -289,12 +301,12 @@
       </select>
     </div>
 
-    <div class="all-charts">
-      <div class="box chart1">
+    <div class={chartLayout}>
+      <div class="box chart1 {chartWidth}">
         <VoltageChart readings={displayedReadings} />
       </div>
 
-      <div class="box chart2">
+      <div class="box chart2 {chartWidth}">
         <TempChart
           {tempDisplay}
           readings={displayedReadings}
@@ -302,11 +314,11 @@
         />
       </div>
 
-      <div class="box chart3">
+      <div class="box chart3 {chartWidth}">
         <AQIChart readings={displayedReadings} />
       </div>
 
-      <div class="box chart4">
+      <div class="box chart4 {chartWidth}">
         <HumidityChart readings={displayedReadings} />
       </div>
 
@@ -497,7 +509,7 @@
     height: inherit;
   }
 
-  .all-charts {
+  .charts {
     display: grid;
     grid-template-areas:
       'chart1 chart2'
@@ -511,6 +523,10 @@
   .chart3,
   .chart4 {
     max-width: 475px;
+  }
+
+  .maximize-chart {
+    max-width: 100%;
   }
 
   .chart1 {
@@ -534,10 +550,12 @@
   }
 
   @media (max-width: 1000px) {
-    .all-charts {
+    .charts,
+    .large-charts {
       display: block;
       max-width: 700px;
-      margin: auto;
+      margin-right: auto;
+      margin-left: auto;
     }
 
     .chart1,
@@ -553,8 +571,7 @@
     .date-selector {
       grid-template-columns: repeat(2, 1fr);
     }
-    .all-measurements,
-    .all-charts {
+    .all-measurements {
       display: block;
     }
     .speedometer-box,

--- a/src/routes/[deviceUID]/dashboard/Actions.svelte
+++ b/src/routes/[deviceUID]/dashboard/Actions.svelte
@@ -6,6 +6,8 @@
   import type { AirnoteReading } from '$lib/services/AirReadingModel';
   import { shareDashboard } from '$lib/util/share';
 
+  /* the data passed in here is what is initially fetched in the `getEvents` function. 
+  To adjust the amount of data fetched, adjust the 'TIMEFRAME' constant */
   export let data: AirnoteReading[];
   export let deviceUID: string;
 

--- a/src/routes/styles.css
+++ b/src/routes/styles.css
@@ -167,6 +167,15 @@ hr {
   text-decoration: underline;
 }
 
+/* chart container div with relative positioning and `maintainAspectRatio: false 
+  option required to update the canvas render and display sizes for responsiveness: 
+  https://www.chartjs.org/docs/latest/configuration/responsive.html#important-note */
+.chart-container {
+  position: relative;
+  min-height: 300px;
+  aspect-ratio: 1.4;
+}
+
 @media (max-width: 992px) {
   section {
     max-width: 720px;
@@ -179,5 +188,11 @@ hr {
   .toasts .toast {
     min-width: 40vw !important;
     min-height: 36px !important;
+  }
+
+  @media (max-width: 520px) {
+    .chart-container {
+      min-height: auto;
+    }
   }
 }


### PR DESCRIPTION
# Problem Context

Increase the amount of historical data display options for individual device dashboard graphs. We have access to more than just the last 7 days' worth of data. So users should be able to see and download it if they want.

## Changes

* Adjust charts configs so they can responsively resize based on if their containers get the `maximize-chart` CSS class passed to them.
* Fetch the last 30 days' worth of data for each Airnote device from Notehub, and allow that to be downloaded by the user.
* Change the available date ranges in the dropdown on the dashboard for the charts to 1, 7, 14 and 30 days. When 30 days is selected make the charts adjust to take up a full row to give users a better look at the amount of data points displayed in a 30 day time period. All other time frames the charts should maintain their original size and configuration based on screen size.
* Fix broken unit tests that weren't properly working because the `getPathname()` function's `decodeURIComponent` doesn't like the test data for some reason

## Screenshot (if applicable)

https://github.com/blues/airnote.live/assets/20400845/44ff708f-67f3-4070-8147-411990ddf66b

## Testing

Unit / integration / e2e tests?

All unit and e2es pass locally.

Steps to test manually?

1. Go to http://localhost:5173/dev:864475046544754
2. Go to the dashboard
3. Download a CSV of the data, see that it has the last months' worth of data included
4. Scroll down to the graphs
5. Change the graph dropdown to 30 days and see the graphs expand to take up a full row 
6. Change the graph dropdown to any other time frame and see the graphs shrink back down to their previous sizes and layout
7. Try navigating to the page via: /dev%3A864475044239001?product=product%3Aorg.airnote.solar.air.v1&pin= and ensure the `getPathname()` function that decodes the URI is still working as expected and it handles the URL successfully

Any other sorts of testing notes to include?

The device dev:864475046544754 has _a lot_ of data points, so it's a good one to test the dashboard's rendering performance and graph displays with.

## Any other related PRs

n/a

## Ticket(s)

https://trello.com/c/jQotETjg/39-airnote-dashboard-ui-allow-user-to-view-more-than-the-last-7-days
