### PR TITLE
feat: downloadable CSV data readings fetch last 90 days' worth of device data

### DIFF
--- a/src/lib/services/notehub.ts
+++ b/src/lib/services/notehub.ts
@@ -82,11 +82,10 @@ export async function updateDeviceEnvironmentVariablesByPin(
 }
 
 // get events from Airnote project in Notehub
-export async function getEvents(deviceUID: string) {
+export async function getEvents(deviceUID: string, timeframe = '30 days') {
   /* this function is fetched on mount with 30 days' worth of data to
 		  populate the CSV download, the AQI average history AND
 		  display today's most current reading as well */
-  const TIMEFRAME = '30 days';
 
   const body = {
     req: 'hub.app.data.query',
@@ -96,7 +95,7 @@ export async function getEvents(deviceUID: string) {
       limit: 12000,
       order: '.modified',
       descending: true,
-      where: `.file::text='_air.qo' and .device::text='${deviceUID}' and .modified >= now()-interval '${TIMEFRAME}'`
+      where: `.file::text='_air.qo' and .device::text='${deviceUID}' and .modified >= now()-interval '${timeframe}'`
     }
   };
 

--- a/src/routes/[deviceUID]/dashboard/+page.svelte
+++ b/src/routes/[deviceUID]/dashboard/+page.svelte
@@ -148,7 +148,7 @@
       </span>
     </h2>
 
-    <Actions data={readings} {deviceUID} />
+    <Actions {deviceUID} />
 
     <div class="all-measurements box">
       <h3 class="current-readings-title">Current Reading</h3>

--- a/src/routes/[deviceUID]/dashboard/Actions.svelte
+++ b/src/routes/[deviceUID]/dashboard/Actions.svelte
@@ -1,32 +1,19 @@
 <script lang="ts">
-  import { unparse } from 'papaparse';
   import DownloadIcon from '$lib/icons/DownloadIcon.svelte';
   import PrintIcon from '$lib/icons/PrintIcon.svelte';
   import ShareIcon from '$lib/icons/ShareIcon.svelte';
-  import type { AirnoteReading } from '$lib/services/AirReadingModel';
   import { shareDashboard } from '$lib/util/share';
 
-  /* the data passed in here is what is initially fetched in the `getEvents` function. 
-  To adjust the amount of data fetched, adjust the 'TIMEFRAME' constant */
-  export let data: AirnoteReading[];
   export let deviceUID: string;
-
-  const downloadData = () => {
-    const csv = 'data:text/csv;charset=utf-8,' + unparse(data);
-    const encodedURI = encodeURI(csv);
-
-    var link = document.createElement('a');
-    link.setAttribute('href', encodedURI);
-    link.setAttribute('download', 'airnote.csv');
-    link.click();
-  };
 </script>
 
 <div class="actions">
-  <button on:click={downloadData}>
-    <DownloadIcon />
-    <span>Download</span>
-  </button>
+  <a rel="external" href={`/api/download?deviceUID=${deviceUID}`}>
+    <button>
+      <DownloadIcon />
+      <span>Download</span>
+    </button>
+  </a>
 
   <button on:click={() => window.print()}>
     <PrintIcon />

--- a/src/routes/api/download/+server.ts
+++ b/src/routes/api/download/+server.ts
@@ -1,4 +1,4 @@
-import pkg from 'papaparse';
+import { unparse } from 'papaparse';
 import {
   getEvents,
   getDeviceEnvironmentVariables
@@ -6,8 +6,6 @@ import {
 import { getCurrentReadings } from '$lib/services/device';
 import type { NotehubEvent } from '$lib/services/NotehubEventModel.js';
 import type { AirnoteReading } from '$lib/services/AirReadingModel.js';
-
-const { unparse } = pkg;
 
 export async function GET({ url }) {
   const allEvents: NotehubEvent[] = [];

--- a/src/routes/api/download/+server.ts
+++ b/src/routes/api/download/+server.ts
@@ -1,0 +1,39 @@
+import { unparse } from 'papaparse';
+import {
+  getEvents,
+  getDeviceEnvironmentVariables
+} from '$lib/services/notehub.js';
+import { getCurrentReadings } from '$lib/services/device';
+import type { NotehubEvent } from '$lib/services/NotehubEventModel.js';
+import type { AirnoteReading } from '$lib/services/AirReadingModel.js';
+
+export async function GET({ url }) {
+  const allEvents: NotehubEvent[] = [];
+  let readings: AirnoteReading[] = [];
+
+  const deviceUID = String(url.searchParams.get('deviceUID'));
+
+  await Promise.all([
+    getDeviceEnvironmentVariables(deviceUID),
+    getEvents(deviceUID, '90 days')
+  ])
+    .then((responses) => {
+      const [envVarResponse, eventsResponse] = responses;
+      const serialNumber = envVarResponse.environment_variables._sn;
+      allEvents.push(...eventsResponse);
+      allEvents.forEach((entry) => (entry.serial_number = serialNumber));
+      readings = getCurrentReadings(allEvents, deviceUID);
+    })
+    .catch((err) => {
+      console.error('Error downloading CSV: ', err);
+    });
+
+  const csv = unparse(readings);
+
+  return new Response(csv, {
+    headers: {
+      'Content-Type': 'text/csv',
+      'Content-Disposition': 'attachment; filename=airnote.csv'
+    }
+  });
+}

--- a/src/routes/api/download/+server.ts
+++ b/src/routes/api/download/+server.ts
@@ -1,4 +1,4 @@
-import { unparse } from 'papaparse';
+import pkg from 'papaparse';
 import {
   getEvents,
   getDeviceEnvironmentVariables
@@ -6,6 +6,8 @@ import {
 import { getCurrentReadings } from '$lib/services/device';
 import type { NotehubEvent } from '$lib/services/NotehubEventModel.js';
 import type { AirnoteReading } from '$lib/services/AirReadingModel.js';
+
+const { unparse } = pkg;
 
 export async function GET({ url }) {
   const allEvents: NotehubEvent[] = [];


### PR DESCRIPTION
# Problem Context

Currently the Airnote dashboard only provides CSV downloads of the last 30 days' worth of data for users, even though we store up to the last 90 days' worth of data in Notehub.

## Changes

* Make `getEvents()` function configurable so it defaults to fetching 30 days' worth of data but can accommodate different data sizes as requested
* Delete client-side `downloadData()` function from `Actions.ts` file and instead make the download button a link that hits the `api/download` route to fetch and download the CSV data server side now
* Create a new `+server.ts` file under the route `api/download` to get all the events associated with a particular device for the past 90 days from Notehub and format that data into a CSV downloaded to the user's local computer afterwards

## Screenshot (if applicable)

n/a

## Testing

Unit / integration / e2e tests?

All automated tests pass.

Steps to test manually?

1. Go to http://localhost:5173/dev:864475044215258/dashboard
2. Go to the Dashboard page
3. Click the download button
4. Check the newly downloaded CSV to ensure the past 90 days' worth of data (if available) is included in the file. This will be under the `captured` column

Any other sorts of testing notes to include?

## Any other related PRs

n/a

## Ticket(s)

https://trello.com/c/q10vjzhh/552-make-downloadable-csv-data-readings-fetch-last-90-days-worth-of-airnote-device-data