### PR TITLE
feat: bold current nav link

### DIFF
--- a/src/lib/layout/Header.svelte
+++ b/src/lib/layout/Header.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { page } from '$app/stores';
   import { onMount } from 'svelte';
   import { afterNavigate } from '$app/navigation';
   import CloseIcon from '$lib/icons/CloseIcon.svelte';
@@ -22,6 +23,9 @@
   let productUID: PotentiallyNullDeviceDetails = '';
   let deviceUID: string = '';
 
+  let activePage: string | null = '';
+  $: activePage = $page.route.id;
+
   onMount(() => {
     const location = window.location;
     const currentDevice: AirnoteDevice = getCurrentDeviceFromUrl(location);
@@ -38,19 +42,28 @@
   </a>
   <ul class={menuOpen ? 'open' : ''}>
     <li>
-      <a href="/quickstart" data-cy="quickstart-link">Quickstart</a>
+      <a
+        href="/quickstart"
+        data-cy="quickstart-link"
+        class:active={activePage === '/quickstart'}>Quickstart</a
+      >
     </li>
     {#if deviceUID}
       <li>
         <a
           href="/{deviceUID}?product={productUID}&pin={pin}&internalNav=true"
           data-cy="settings-link"
+          class:active={activePage === '/[deviceUID]'}
         >
           Settings
         </a>
       </li>
       <li>
-        <a href="/{deviceUID}/dashboard" data-cy="dashboard-link">
+        <a
+          href="/{deviceUID}/dashboard"
+          data-cy="dashboard-link"
+          class:active={activePage && activePage.includes('/dashboard')}
+        >
           Dashboard
         </a>
       </li>
@@ -66,63 +79,74 @@
   header {
     background: var(--notehubBlue);
     display: flex;
-  }
-  header img {
-    height: 24px;
-    margin: 1.25rem 0.5rem 1.25rem 1rem;
-    vertical-align: middle;
-  }
-  header ul {
-    padding: 0;
-    display: flex;
-    list-style: none;
-    color: var(--white);
-    flex-grow: 1;
-    align-self: center;
-    justify-content: flex-end;
-    margin-right: 1rem;
-  }
-  header li {
-    padding-left: 1rem;
-  }
-  header ul a {
-    color: var(--white);
-  }
-  header .svg-button {
-    border: 1px solid var(--white);
-    align-self: center;
-    margin-right: 1rem;
-    justify-content: center;
-    align-items: center;
-    display: none;
-  }
 
-  @media (max-width: 600px) {
-    header {
+    /* CSS nesting @media queries inside different selectors: https://developer.chrome.com/docs/css-ui/css-nesting */
+    @media (max-width: 600px) {
       justify-content: space-between;
       position: relative;
     }
-    header ul {
-      position: absolute;
-      top: 48px;
-      left: 0;
-      z-index: 2;
-      width: 100%;
-      background: var(--notehubBlue);
-      display: none;
-      text-align: center;
+    & :is(img) {
+      height: 24px;
+      margin: 1.25rem 0.5rem 1.25rem 1rem;
+      vertical-align: middle;
     }
-    header ul.open {
-      display: block;
-    }
-    header li {
-      display: block;
-      padding: 1rem;
-      border: 1px solid var(--white);
-      border-width: 1px 0;
-    }
-    header .svg-button {
+
+    & :is(ul) {
+      padding: 0;
       display: flex;
+      list-style: none;
+      color: var(--white);
+      flex-grow: 1;
+      align-self: center;
+      justify-content: flex-end;
+      margin-right: 1rem;
+
+      @media (max-width: 600px) {
+        position: absolute;
+        top: 48px;
+        left: 0;
+        z-index: 2;
+        width: 100%;
+        background: var(--notehubBlue);
+        display: none;
+        text-align: center;
+
+        &.open {
+          display: block;
+        }
+      }
+
+      & :is(li) {
+        padding-left: 1rem;
+
+        @media (max-width: 600px) {
+          display: block;
+          padding: 1rem;
+          border: 1px solid var(--white);
+          border-width: 1px 0;
+        }
+
+        & :is(a) {
+          color: var(--white);
+        }
+
+        & :is(.active) {
+          font-weight: 600;
+        }
+      }
+    }
+
+    & .svg-button {
+      border: 1px solid var(--white);
+      align-self: center;
+      margin-right: 1rem;
+      justify-content: center;
+      align-items: center;
+      display: none;
+
+      @media (max-width: 600px) {
+        display: flex;
+      }
     }
   }
 </style>


### PR DESCRIPTION
# Problem Context

When on a particular page (Settings, Dashboard, Quickstart), bold the current selection in the nav bar 

## Changes

* [Conditionally render `active` class](https://sveltebyexample.com/class-and-style-directives/) on nav bar links in `<Header />` component based on what page is currently active, as identified using the Svelte [`page`](https://kit.svelte.dev/docs/modules#$app-stores-page) object.
* Update `<Header />` component CSS to use nesting, including media query nesting (I was in there anyway and seemed like a good time to practice using the new CSS nesting that's now widely supported).

## Screenshot (if applicable)

https://github.com/blues/airnote.live/assets/20400845/74aefcfe-1fe9-43ed-84f5-e3555566fcfa

## Testing

Unit / integration / e2e tests?

All tests continue to pass.

Steps to test manually?

1. Go to http://localhost:5137. Note that none of the nav bar links are highlighted because it's on the homepage of the site
2. Go to Quickstart page. See that Quickstart nav bar link is bold.
3. Go to Settings page. See that Settings nav bar link is now bold.
4. Go to Dashboard page. See that Dashboard nav bar link is now bold.
5. Go back to homepage. See that all nav bar links are now normal font weight.
6. Check in mobile view as well to make sure links are bold there too.

Any other sorts of testing notes to include?

## Any other related PRs

n/a

## Ticket(s)

https://trello.com/c/G06VZS2C/565-airnote-dashboard-ui-when-on-a-particular-page-settings-or-dashboard-bold-the-current-selection
