### PR TITLE
feat: add safecast grafana link to dashboard

### DIFF
--- a/src/routes/[deviceUID]/dashboard/+page.svelte
+++ b/src/routes/[deviceUID]/dashboard/+page.svelte
@@ -326,6 +326,15 @@
         <PMChart readings={displayedReadings} />
       </div>
     </div>
+    <div class="safecast-link">
+      <a
+        href="http://tt.safecast.org/dashboard/note:{deviceUID}"
+        class="svg-link"
+        target="_blank"
+      >
+        <span>View full data at Safecast.org</span>
+      </a>
+    </div>
     {#if showBanner}
       <div class="banner">
         <p>
@@ -417,6 +426,10 @@
 
   .box h3 {
     margin-top: 0;
+  }
+
+  .safecast-link {
+    padding: 0.25rem 0 0 0;
   }
 
   .banner {

--- a/src/routes/[deviceUID]/dashboard/+page.svelte
+++ b/src/routes/[deviceUID]/dashboard/+page.svelte
@@ -332,7 +332,7 @@
         class="svg-link"
         target="_blank"
       >
-        <span>View full data at Safecast.org</span>
+        <span>View additional data at Safecast.org</span>
       </a>
     </div>
     {#if showBanner}


### PR DESCRIPTION
# Problem Context

We route all Airnote data to a Safecast-maintained Grafana dashboard that users can access at `http://tt.safecast.org/dashboard/note:{deviceUID}`.

We previously included that link in the airnote.live dashboards, but removed it when we added our own graphs.

It was requested we bring the link back, as Grafana allows much more flexibility for viewing data—specifically that it allows greater date rates and to go further back in time.

## Changes

* Add link to the Safecast Grafana dashboards at the bottom of the Airnote dashboard page

## Screenshot (if applicable)

![Screenshot 2024-02-15 at 12 43 47 PM](https://github.com/blues/airnote.live/assets/20400845/21f5332b-1aa0-4dde-b339-0d00e340f886)

## Testing

Unit / integration / e2e tests?

All unit and e2e tests pass locally.

Steps to test manually?

1. Go to http://localhost:5173/dev:864475044215258/dashboard
2. Scroll down to the bottom of the dashboard page
3. See the "View Additional data at Safecast.org" link
4. Click it and see Grafana charts of additional Airnote information

Any other sorts of testing notes to include?

## Any other related PRs

n/a

## Ticket(s)

https://bluesinc.atlassian.net/jira/software/c/projects/BLUESDEV/issues/BLUESDEV-20?filter=allissues
