### PR TITLE
feat: move redirect logic when coming from notehub dashboard from client side to server side

### DIFF
--- a/src/routes/[deviceUID]/+page.server.ts
+++ b/src/routes/[deviceUID]/+page.server.ts
@@ -1,4 +1,4 @@
-import { fail } from '@sveltejs/kit';
+import { fail, redirect } from '@sveltejs/kit';
 import {
   getDeviceEnvironmentVariables,
   getDeviceEnvironmentVariablesByPin,
@@ -22,6 +22,14 @@ import type { DeviceEnvVars } from '$lib/services/DeviceEnvVarModel.js';
 export async function load({ params, url }) {
   const deviceUID = params.deviceUID;
   const pin = url.searchParams.get('pin');
+  const internalNav = url.searchParams.get('internalNav');
+
+  /* Notehub links to a device’s dashboard using `/${deviceUID}` with no pin,
+    and we want Notehub users to view the device’s dashboard, and not the
+    settings page when first directed there from Notehub. */
+  if (deviceUID && !pin && internalNav === null) {
+    redirect(302, `/${deviceUID}/dashboard`);
+  }
 
   let notehubError: { status: number } | undefined;
   let error;

--- a/src/routes/[deviceUID]/+page.svelte
+++ b/src/routes/[deviceUID]/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { goto } from '$app/navigation';
   import { NotificationDisplay, notifier } from '@beyonk/svelte-notifications';
   import { APP_UID, RADNOTE_PRODUCT_UID } from '$lib/constants';
   import { getCurrentDeviceFromUrl } from '$lib/services/device';
@@ -23,7 +22,6 @@
   } from '$lib/services/DeviceModel';
   import { ERROR_TYPE } from '$lib/constants/ErrorTypes';
   import { renderErrorMessage } from '$lib/util/errors';
-  import { getPathname } from '$lib/util/url';
 
   export let pin: PotentiallyNullDeviceDetails = '';
   export let deviceUID: string = '';

--- a/src/routes/[deviceUID]/+page.svelte
+++ b/src/routes/[deviceUID]/+page.svelte
@@ -141,18 +141,6 @@
       ? currentDevice.internalNav
       : 'false';
     productUID = currentDevice.productUID ? currentDevice.productUID : '';
-
-    /* Notehub links to a device’s dashboard using `/${deviceUID}` with no pin,
-    and we want Notehub users to view the device’s dashboard, and not the
-    settings page when first directed there from Notehub. */
-    if (
-      deviceUID &&
-      getPathname() === '/' + deviceUID &&
-      !pin &&
-      internalNav === 'false'
-    ) {
-      goto(`/${deviceUID}/dashboard`, { replaceState: true });
-    }
   });
 </script>
 


### PR DESCRIPTION
# Problem Context

In the Notehub Airnote project, if you go to a device page and click its Dashboard link (top-right corner) you can visits the device’s dashboard on airnote.live.

The link works, however, after clicking the link you start by seeing the Settings page on airnote.live “flash” for a second before being redirected to the Dashboard.

Since we use this link from Notehub a lot in demos, we should attempt to avoid the flash and have the Dashboard load smoothly.

## Changes

* Move the redirect logic which previously lived client-side in the app and only ran after the browser page had loaded to the server-side so now it runs and performs the redirect before the browser page has loaded.

## Screenshot (if applicable)

Browser on left side is current Airnote site when coming from Notehub, browser on right is "fixed" experience when coming from Notehub

https://github.com/blues/airnote.live/assets/20400845/ea571ea9-80f3-4590-969c-7f5dd713afa5

## Testing

Unit / integration / e2e tests?

All unit and e2e tests pass

Steps to test manually?

1. Enter the following URL into an incognito browser window to simulate what it's like coming from the Notehub Airnote project to the Airnote dashboard: http://localhost:5173/dev%3A864475044215258?product=product%3Aorg.airnote.solar.air.v1&pin=
2. Watch that the page loads on the Airnote dashboard page with no flash of the Settings page beforehand
3. If you try the same URL again but add a pin number (even if it's a bogus one), the page will not land on the dashboard, but on the settings page
4. Now visit the same page in production today: https://airnote.live/dev%3A864475044215258?product=product%3Aorg.airnote.solar.air.v1&pin=
5. See that there is a flash of the Settings page before the browser redirects to the dashboard page

Any other sorts of testing notes to include?

## Any other related PRs

n/a

## Ticket(s)

https://bluesinc.atlassian.net/jira/software/c/projects/BLUESDEV/issues/BLUESDEV-19?filter=allissues
