### PR TITLE
chore: make safecast grafana link visible even when dashboard errors

### DIFF
--- a/src/routes/[deviceUID]/dashboard/+page.svelte
+++ b/src/routes/[deviceUID]/dashboard/+page.svelte
@@ -326,15 +326,6 @@
         <PMChart readings={displayedReadings} />
       </div>
     </div>
-    <div class="safecast-link">
-      <a
-        href="http://tt.safecast.org/dashboard/note:{deviceUID}"
-        class="svg-link"
-        target="_blank"
-      >
-        <span>View additional data at Safecast.org</span>
-      </a>
-    </div>
     {#if showBanner}
       <div class="banner">
         <p>
@@ -349,6 +340,17 @@
         </button>
       </div>
     {/if}
+  {/if}
+  {#if deviceUID}
+    <div class="safecast-link">
+      <a
+        href="http://tt.safecast.org/dashboard/note:{deviceUID}"
+        class="svg-link"
+        target="_blank"
+      >
+        <span>View additional data at Safecast.org</span>
+      </a>
+    </div>
   {/if}
 </div>
 

--- a/src/routes/[deviceUID]/dashboard/+page.svelte
+++ b/src/routes/[deviceUID]/dashboard/+page.svelte
@@ -45,6 +45,7 @@
 
   let error = false;
   let errorType: string;
+  let safecastLinkText = 'View additional data at Safecast.org';
 
   let tempDisplay: string = 'C';
   let showBanner: boolean = true;
@@ -73,6 +74,7 @@
   if (!readings || readings.length === 0) {
     error = true;
     errorType = ERROR_TYPE.NO_DATA_ERROR;
+    safecastLinkText = 'Check for historical data at Safecast.org';
   } else {
     lastReading = readings[0];
 
@@ -348,7 +350,7 @@
         class="svg-link"
         target="_blank"
       >
-        <span>View additional data at Safecast.org</span>
+        <span>{safecastLinkText}</span>
       </a>
     </div>
   {/if}

--- a/src/routes/styles.css
+++ b/src/routes/styles.css
@@ -157,7 +157,7 @@ hr {
   border: 1px solid var(--alertBorderRed);
   padding: 1rem;
   border-radius: 0.25rem;
-  margin-top: 1rem;
+  margin: 1rem 0;
 
   & :is(h4) {
     color: var(--alertTextRed);


### PR DESCRIPTION
# Problem Context

The link to the Safecast Grafana charts should be accessible on the Airnote dashboard even if the dashboard itself doesn't show any data for debugging purposes.

## Changes

Move the Grafana links outside of the `{#if}` that keeps the link from rendering if an error state is displayed on the page. Now, all that's needed is for a deviceUID to be present (which should always exist since it's in the URL)

## Screenshot (if applicable)

![Screenshot 2024-02-16 at 1 26 14 PM](https://github.com/blues/airnote.live/assets/20400845/1186ad03-03f2-4c13-b708-1776830a2443)

![Screenshot 2024-02-16 at 1 26 34 PM](https://github.com/blues/airnote.live/assets/20400845/f0678b5a-3bb0-425b-801e-02f5e151941f)

## Testing

Unit / integration / e2e tests?

All tests continue to pass.

Steps to test manually?

1. Go to the following URL: http://localhost:5173/dev:865284040097903/dashboard?product=product%3Acom.blues.airnote&pin=
2. See that even though a "no data" error message is shown the Grafana link is still visible

Any other sorts of testing notes to include?

## Any other related PRs

n/a

## Ticket(s)

https://bluesinc.atlassian.net/browse/BLUESDEV-20
