### PR TITLE
docs: fix a11y warning about image alt text already announced as images on screenreaders

### DIFF
--- a/src/quickstart/02-unboxing-your-airnote.mdx
+++ b/src/quickstart/02-unboxing-your-airnote.mdx
@@ -2,7 +2,7 @@
 
 ## Unboxing Your Airnote
 
-![Picture of the Airnote box](images/guides/airnote/box.png)
+![Airnote box](images/guides/airnote/box.png)
 
 Open the Airnote box. Inside, you'll find:
 
@@ -11,7 +11,7 @@ Open the Airnote box. Inside, you'll find:
 - Eight velcro Command Strips in two clear plastic bags.
 - One Airnote.
 
-![Image of the contents of the Airnote box](images/guides/airnote/components.png)
+![Contents of the Airnote box](images/guides/airnote/components.png)
 
 <Note>
 

--- a/src/quickstart/03-airnote-setup.mdx
+++ b/src/quickstart/03-airnote-setup.mdx
@@ -15,7 +15,7 @@ connection to the cloud. If you scan the code before
 your Airnote is online, you'll see an
 error message on the airnote.live configuration page for your device.
 
-![Screenshot of error on landing page](images/guides/airnote/lperror.png)
+![Error on landing page](images/guides/airnote/lperror.png)
 
 </Note>
 
@@ -26,17 +26,17 @@ first connection to the [Notehub.io](https://notehub.io) cloud service,
 you'll next want to turn it on. Find the black slide switch at the base of
 the device between the two screws and turn on your Airnote.
 
-![image of the power switch at the base of the Airnote](/images/guides/airnote/switch.png)
+![Power switch at the base of the Airnote](/images/guides/airnote/switch.png)
 
 Once you've flipped the switch, look at the LCD screen on the back.
 
-![image showing the location of the LCD screen](images/guides/airnote/lcd-screen.png)
+![The location of the LCD screen](images/guides/airnote/lcd-screen.png)
 
 If you
 see anything on the screen, that means the device has started its self-test
 sequence, and you're ready for the next step.
 
-![image of the 3 dots on the LCD during initialization](images/guides/airnote/lcd-init.png)
+![The 3 dots on the LCD during initialization](images/guides/airnote/lcd-init.png)
 
 <Note>
 
@@ -63,13 +63,13 @@ one side of each pair and place one above and one below the LCD screen on
 the back of the device. This is the side that you will want to be
 visible through a window.
 
-![image of command strips on the device](/images/guides/airnote/commandstrips.png)
+![Command strips on the device](/images/guides/airnote/commandstrips.png)
 
 Next, remove the backing tape from the still exposed sides of the
 Command Strips and secure it to your preferred location. We've provided eight
 strips in total just in case you ever need to reposition the device.
 
-![image of the Airnote mounted on an exterior window](images/guides/airnote/window.png)
+![Airnote mounted on an exterior window](images/guides/airnote/window.png)
 
 <Note>
 
@@ -96,7 +96,7 @@ Now, you're ready to customize your device. Open a QR code reader on
 your mobile device and scan the QR code on the back of the Airnote, just
 below the LCD screen.
 
-![image of a person scanning the Airnote QR code with a phone](images/guides/airnote/scan.png)
+![Person scanning the Airnote QR code with a phone](images/guides/airnote/scan.png)
 
 The code on each Airnote is unique to the device and directs you to
 a personalized landing page here on [airnote.live](/). From this
@@ -113,17 +113,17 @@ cellular connection and refresh the page to try again.
 
 </Note>
 
-![image of the Airnote landing page](images/guides/airnote/airnotelp.png)
+![Airnote landing page](images/guides/airnote/airnotelp.png)
 
 The device settings section allows you to assign a name to the device, set how
 often the Airnote should sample readings from its onboard sensors, and which
 sensor value (like temperature, humidity, pressure, etc.) to display on the
 built-in screen.
 
-![Image of the device settings section of the Airnote landing page](images/guides/airnote/devicesettings.png)
+![Device settings section of the Airnote landing page](images/guides/airnote/devicesettings.png)
 
 The owner settings section allows you to share your contact information
 with other members of the global Safecast network. Again, this information
 is optional.
 
-![Image of the owner settings section of the Airnote landing page](/images/guides/airnote/ownersettings.png)
+![Owner settings section of the Airnote landing page](/images/guides/airnote/ownersettings.png)

--- a/src/quickstart/04-visit-your-device-dashboard.mdx
+++ b/src/quickstart/04-visit-your-device-dashboard.mdx
@@ -8,7 +8,7 @@ readings over time. You can access the your dashboard by visiting
 The easiest way to access this URL is by scanning the QR code on your Airnote,
 and then clicking the **View your device's dashboard** button.
 
-![Image of the Notehub.io events screen for a device](/images/guides/airnote/dashboard-link.png)
+![Notehub.io events screen for a device](/images/guides/airnote/dashboard-link.png)
 
 The Airnote dashboard displays current air quality information, as well as historical readings
 over the past seven days.
@@ -18,4 +18,4 @@ over the past seven days.
 From the Airnote dashboard, you can also get a link to the [Notehub.io](https://notehub.io)
 Events view for your device, and browse other devices in the public Airnote project.
 
-![Image of the Notehub.io events screen for a device](/images/guides/airnote/eventspage.png)
+![Notehub.io events screen for a device](/images/guides/airnote/eventspage.png)

--- a/src/quickstart/06-faq.mdx
+++ b/src/quickstart/06-faq.mdx
@@ -21,7 +21,7 @@ on, the LCD display will update to indicate that the device is charging.
 When the plus (+) sign on the display disappears, the Airnote is charged and
 ready to mount.
 
-![Image of the LCD Screen with the charging indicator](/images/guides/airnote/usb-chg.png)
+![LCD Screen with the charging indicator](/images/guides/airnote/usb-chg.png)
 
 Once the battery has charged, place the bottom panel back
 on the Airnote and secure the panel with the two included
@@ -40,7 +40,7 @@ LCD screen facing up. The display will update to read "USb" with a
 lowercase "b" and plus (+) sign. The plus sign will disappear when the
 battery is full.
 
-![Image of the LCD Screen with the charging indicator](/images/guides/airnote/usb-chg.png)
+![LCD Screen with the charging indicator](/images/guides/airnote/usb-chg.png)
 
 ### Can I check the current voltage of my Airnote?
 
@@ -53,7 +53,7 @@ When the Airnote's built-in accelerometer detects this orientation (which might 
 several seconds), the built-in display will update to indicate the current voltage of
 the device's battery. Anything over 4 volts indicates the battery is full.
 
-![Image of the LCD Screen with voltage](/images/guides/airnote/voltage.png)
+![LCD Screen with voltage](/images/guides/airnote/voltage.png)
 
 ### Can I use the Airnote indoors?
 
@@ -97,7 +97,7 @@ location and try again.
 
 ### My Airnote is displaying a numeric code. What does that mean?
 
-If the Airnote is experiencing an error or other issue with one of its 
+If the Airnote is experiencing an error or other issue with one of its
 components, a status code may appear:
 
 - `1xx` BME280 OK
@@ -109,8 +109,8 @@ components, a status code may appear:
 - `x1x` Air Particle Counter OK
 - `999` Airnote Configuration Error
 
-In some cases, Airnotes that have been deployed outdoors for many months (and 
-display one of these codes) may need to be opened and inspected for insect 
+In some cases, Airnotes that have been deployed outdoors for many months (and
+display one of these codes) may need to be opened and inspected for insect
 debris.
 
 ### Do I need to update the Airnote firmware or activate the device?


### PR DESCRIPTION
# Problem Context

I noticed today while firing up a local instance of Airnote that a bunch of A11y warnings pop up on the quickstart page due to the alt text provided in the mdx files that amounts to "you're being redundant with alt text that includes 'this is an image of ...' because screenreaders already announce it's an image"

## Changes

* Adjust alt text on quickstart MDX docs to not be redundant with text like "Picture of" or "Image of" or "Screenshot of"

## Screenshot (if applicable)

previous warnings during local dev on quickstart docs page

<img width="1482" alt="Screenshot 2024-04-17 at 1 23 40 PM" src="https://github.com/blues/airnote.live/assets/20400845/d73291c2-1a95-4731-9df3-f0d2b9b80352">

no warnings now on local dev on quickstart docs page

<img width="340" alt="Screenshot 2024-04-17 at 1 26 38 PM" src="https://github.com/blues/airnote.live/assets/20400845/4e7eafbd-62f8-437d-a42c-5a3f02bf2f0a">

## Testing

Unit / integration / e2e tests?
Steps to test manually?

1. Start the local app
2. Go to http://localhost:5173/quickstart
3. Check the terminal where the app is running and see that there's no warnings about A11y screenreaders

Any other sorts of testing notes to include?

## Any other related PRs

n/a

## Ticket(s)

n/a
