### PR TITLE
chore: remove links to Safecast Grafana dashboards that no longer work

### DIFF
--- a/src/routes/[deviceUID]/DeviceSettings.svelte
+++ b/src/routes/[deviceUID]/DeviceSettings.svelte
@@ -77,8 +77,7 @@
         name="indoorDevice"
         id="indoorDevice"
       />
-      <span>Indoor device (Will not be visible on the Safecast global map)</span
-      >
+      <span>Indoor device (Will not be visible on the global map)</span>
     </label>
   </div>
 

--- a/src/routes/[deviceUID]/dashboard/+page.svelte
+++ b/src/routes/[deviceUID]/dashboard/+page.svelte
@@ -45,7 +45,6 @@
 
   let error = false;
   let errorType: string;
-  let safecastLinkText = 'View additional data at Safecast.org';
 
   let tempDisplay: string = 'C';
   let showBanner: boolean = true;
@@ -74,7 +73,6 @@
   if (!readings || readings.length === 0) {
     error = true;
     errorType = ERROR_TYPE.NO_DATA_ERROR;
-    safecastLinkText = 'Check for historical data at Safecast.org';
   } else {
     lastReading = readings[0];
 
@@ -343,17 +341,6 @@
       </div>
     {/if}
   {/if}
-  {#if deviceUID}
-    <div class="safecast-link">
-      <a
-        href="http://tt.safecast.org/dashboard/note:{deviceUID}"
-        class="svg-link"
-        target="_blank"
-      >
-        <span>{safecastLinkText}</span>
-      </a>
-    </div>
-  {/if}
 </div>
 
 {#if tooltipState !== TOOLTIP_STATES.CLOSED}
@@ -430,10 +417,6 @@
 
   .box h3 {
     margin-top: 0;
-  }
-
-  .safecast-link {
-    padding: 0.25rem 0 0 0;
   }
 
   .banner {


### PR DESCRIPTION
# Problem Context

The Safecast pipeline feeding data to the Grafana dashboards is no longer operating. Remove links to the Grafana dashboard from the Airnote site.

## Changes

* Remove link at the bottom of the Airnote dashboard page that linked to the Grafana dashboard

## Screenshot (if applicable)

Live Airnote site (link to Grafana still there)

![Screenshot 2024-06-24 at 9 52 10 AM](https://github.com/blues/airnote.live/assets/20400845/1ce1c0e5-62c3-444e-a0ae-63d4fe7565ee)

Update Airnote site (link to Grafana removed)

![Screenshot 2024-06-24 at 9 52 04 AM](https://github.com/blues/airnote.live/assets/20400845/31a99839-dd40-411f-9c9e-40cb3cdab800)

## Testing

Unit / integration / e2e tests?

Test still pass

Steps to test manually?

1. Go to http://localhost:5173/dev:864475044215258/dashboard
2. Scroll to the bottom of the page
3. See that underneath the last chart and Safecast banner there is no longer a link to the Safecast Grafana dashboards

Any other sorts of testing notes to include?

## Any other related PRs

n/a

## Ticket(s)

https://bluesinc.atlassian.net/jira/software/c/projects/BLUESDEV/boards/13?selectedIssue=BLUESDEV-379
