### PR TITLE
bug: reduce number of events query pulls from Notehub at once

### DIFF
--- a/src/lib/services/notehub.ts
+++ b/src/lib/services/notehub.ts
@@ -92,7 +92,7 @@ export async function getEvents(deviceUID: string, timeframe = '30 days') {
     query: {
       columns:
         ".body;.when;lat:(events.value->'best_lat');lon:(events.value->'best_lon');location:(events.value->'best_location')",
-      limit: 12000,
+      limit: 10000,
       order: '.modified',
       descending: true,
       where: `.file::text='_air.qo' and .device::text='${deviceUID}' and .modified >= now()-interval '${timeframe}'`


### PR DESCRIPTION
# Problem Context

The Airnote dashboards stopped reporting data, even for devices that have checked in within the last week. Find the cause and fix the issue.

## Changes

The `getEvents()` function we use to pull Airnote data from Notehub was modified to only return up to 10000 events, however, the query was trying to request 12000.

Back down the query limit to 10000.

## Screenshot (if applicable)

![Screenshot 2024-07-23 at 10 13 15 AM](https://github.com/user-attachments/assets/b9077986-5b64-4c48-aceb-4960d1da1f10)

## Testing

Unit / integration / e2e tests?

No new tests added - the limit changed on Notehub's end without warning, not ours.

Steps to test manually?

1. Go to http://localhost:5173/dev:864475044215258/dashboard
2. See that the dashboard loads correctly and data is shown, and no error occurs

Any other sorts of testing notes to include?

## Any other related PRs

n/a

## Ticket(s)

https://bluesinc.atlassian.net/jira/software/c/projects/BLUESDEV/boards/13?selectedIssue=BLUESDEV-399
