### PR TITLE
bug: fix how Airnote settings data is saved to Notehub

### DIFF
--- a/src/lib/util/url.ts
+++ b/src/lib/util/url.ts
@@ -1,5 +1,11 @@
 // The “Dashboard” link in Notehub links to the Airnote site with
+import { APP_UID } from '$lib/constants';
+
 // a DeviceUID in the format dev%3abcdef.
 export function getPathname() {
   return decodeURIComponent(location.pathname);
+}
+
+export function getNotehubEventsUrl(deviceUID: string) {
+  return `https://notehub.io/project/${APP_UID}/events?filter_dev=${deviceUID}`;
 }

--- a/src/routes/[deviceUID]/+page.svelte
+++ b/src/routes/[deviceUID]/+page.svelte
@@ -22,6 +22,7 @@
   } from '$lib/services/DeviceModel';
   import { ERROR_TYPE } from '$lib/constants/ErrorTypes';
   import { renderErrorMessage } from '$lib/util/errors';
+  import { getNotehubEventsUrl } from '$lib/util/url';
 
   export let pin: PotentiallyNullDeviceDetails = '';
   export let deviceUID: string = '';
@@ -34,7 +35,7 @@
 
   let eventsUrl = `https://notehub.io/project/${APP_UID}/events`;
   $: if (deviceUID) {
-    eventsUrl = `https://notehub.io/project/${APP_UID}/events?filter_dev=${deviceUID}`;
+    eventsUrl = getNotehubEventsUrl(deviceUID);
   }
 
   const deviceDisplayOptions = [

--- a/src/routes/[deviceUID]/+page.svelte
+++ b/src/routes/[deviceUID]/+page.svelte
@@ -34,7 +34,7 @@
 
   let eventsUrl = `https://notehub.io/project/${APP_UID}/events`;
   $: if (deviceUID) {
-    eventsUrl = `https://notehub.io/project/${APP_UID}/events?queryDevice=${deviceUID}`;
+    eventsUrl = `https://notehub.io/project/${APP_UID}/events?filter_dev=${deviceUID}`;
   }
 
   const deviceDisplayOptions = [
@@ -45,7 +45,7 @@
   ];
 
   if (productUID === RADNOTE_PRODUCT_UID) {
-    $displayValue = 'usv';
+    displayValue.set('usv');
 
     deviceDisplayOptions.splice(0, 0, {
       value: 'usv',
@@ -57,7 +57,7 @@
       text: 'LND712 Counts Per Minute'
     });
   } else {
-    $displayValue = 'pm2.5';
+    displayValue.set('pm2.5');
 
     deviceDisplayOptions.splice(0, 0, {
       value: 'pm2.5',
@@ -91,7 +91,7 @@
     if (data['_air_mins']) {
       // Split semi-colon list into an array for parsing and reassembly
       // "usb:15;high:123;normal:123;low:720;0"
-      let airMinsVals = data['_air_mins']
+      const airMinsVals = data['_air_mins']
         .split(';')
         .map((item) => item.split(':'));
       for (let index = 0; index < airMinsVals.length; index++) {

--- a/src/routes/[deviceUID]/+page.svelte
+++ b/src/routes/[deviceUID]/+page.svelte
@@ -41,7 +41,7 @@
     { value: 'tempc', text: 'Temp (°C)' },
     { value: 'tempf', text: 'Temp (°F)' },
     { value: 'humid', text: 'Humidity' },
-    { value: 'press', text: 'Barometric Pressue' }
+    { value: 'press', text: 'Barometric Pressure' }
   ];
 
   if (productUID === RADNOTE_PRODUCT_UID) {
@@ -87,7 +87,7 @@
   }
 
   const updateSettingsFromEnvVars = (data: { [property: string]: string }) => {
-    if (data['_sn']) $deviceName = data['_sn'];
+    if (data['_sn']) deviceName.set(data['_sn']);
     if (data['_air_mins']) {
       // Split semi-colon list into an array for parsing and reassembly
       // "usb:15;high:123;normal:123;low:720;0"
@@ -98,24 +98,24 @@
         const element = airMinsVals[index];
         switch (element[0]) {
           case 'usb':
-            $sampleFrequencyUSB = element[1];
+            sampleFrequencyUSB.set(element[1]);
             break;
           case 'high':
-            $sampleFrequencyFull = element[1];
+            sampleFrequencyFull.set(element[1]);
             break;
           case 'low':
-            $sampleFrequencyLow = element[1];
+            sampleFrequencyLow.set(element[1]);
             break;
         }
       }
     }
     if (data['_air_indoors'])
-      $indoorDevice = data['_air_indoors'] === '0' ? false : true;
-    if (data['_air_status']) $displayValue = data['_air_status'];
-    if (data['_contact_name']) $contactName = data['_contact_name'];
-    if (data['_contact_email']) $contactEmail = data['_contact_email'];
+      indoorDevice.set(data['_air_indoors'] === '0' ? false : true);
+    if (data['_air_status']) displayValue.set(data['_air_status']);
+    if (data['_contact_name']) contactName.set(data['_contact_name']);
+    if (data['_contact_email']) contactEmail.set(data['_contact_email']);
     if (data['_contact_affiliation'])
-      $contactAffiliation = data['_contact_affiliation'];
+      contactAffiliation.set(data['_contact_affiliation']);
   };
 
   if (data.notehubResponse) {

--- a/src/routes/[deviceUID]/dashboard/+page.svelte
+++ b/src/routes/[deviceUID]/dashboard/+page.svelte
@@ -54,7 +54,7 @@
   let eventsUrl = `https://notehub.io/project/${APP_UID}/events`;
 
   $: if (deviceUID) {
-    eventsUrl = `https://notehub.io/project/${APP_UID}/events?queryDevice=${deviceUID}`;
+    eventsUrl = `https://notehub.io/project/${APP_UID}/events?filter_dev=${deviceUID}`;
   }
 
   let expandCharts: boolean = false;

--- a/src/routes/[deviceUID]/dashboard/+page.svelte
+++ b/src/routes/[deviceUID]/dashboard/+page.svelte
@@ -30,6 +30,7 @@
   import MapboxMap from './MapboxMap.svelte';
   import Recommendation from './Recommendation.svelte';
   import Speedometer from './Speedometer.svelte';
+  import { getNotehubEventsUrl } from '$lib/util/url';
 
   export let deviceUID: string;
 
@@ -54,7 +55,7 @@
   let eventsUrl = `https://notehub.io/project/${APP_UID}/events`;
 
   $: if (deviceUID) {
-    eventsUrl = `https://notehub.io/project/${APP_UID}/events?filter_dev=${deviceUID}`;
+    eventsUrl = getNotehubEventsUrl(deviceUID);
   }
 
   let expandCharts: boolean = false;


### PR DESCRIPTION
# Problem Context

Users reported that some settings like device name or owner name and contact info weren't displaying on their Airnote dashboards after saving the values in and refreshing the page.

Also, link to view particular Airnote events in Notehub is broken due to change to Notehub URL query params

## Changes

* Figure out the app's Svelte store (client-side way to hold global state that any part of the app can consume) was not always being properly set / updated after a user saved in new settings and the page was refreshed. Fix it to set those values correctly in the client on page load / refresh.
* Update Notehub link to follow new query params format

## Screenshot (if applicable)

## Testing

Unit / integration / e2e tests?

Steps to test manually?

Reproduce error:
1. In production, go to Settings page of editable Airnote device (i.e. you need a PIN to be able to edit device details)
2. Change the device settings (update name, screen display value, etc.) and save those changes
3. Then update the device owner info (name, affiliation, contact email) and save those changes
4. Refresh the page and see that the device settings have reverted back to previous values
5. On dashboard page, click "View live events on Notehub" link and see all Airnote events, not just events for particular device

Test local fix: 
1. In local, go to Settings page of editable Airnote device (i.e. you need a PIN to be able to edit device details)
2. Change the device settings (update name, screen display value, etc.) and save those changes
3. Then update the device owner info (name, affiliation, contact email) and save those changes
4. Refresh the page and see that the device settings keep newly saved values on page reload / refresh
5. 5. On dashboard page, click "View live events on Notehub" link and see Airnote events just for particular device

Any other sorts of testing notes to include?

This was an obscure bug to reliably reproduce, but research on how store values are not automatically updated when those values change on the client, and [how to set values in stores](https://svelte.dev/docs/svelte-store#writable) from data loaded from the server on page load ultimately helped me solve this bug.

## Any other related PRs

n/a

## Ticket(s)

https://bluesinc.atlassian.net/jira/software/c/projects/BLUESDEV/boards/13?selectedIssue=BLUESDEV-394
https://bluesinc.atlassian.net/jira/software/c/projects/BLUESDEV/boards/13?selectedIssue=BLUESDEV-412