### PR TITLE
chore: swap out v0 get events API call for v1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@beyonk/svelte-notifications": "^4.2.0",
-        "@blues-inc/notehub-js": "^1.0.17",
+        "@blues-inc/notehub-js": "^1.0.22",
         "chart.js": "^4.4.0",
         "date-fns": "^2.30.0",
         "mapbox-gl": "^2.15.0",
@@ -401,9 +401,9 @@
       "integrity": "sha512-ZP/k3lbIB97aJDY5rUK61++RvKABNuK+iek0J2ucAL5h3BOSlU2FyODf2fD49eESnBYIUSxmKU25S3XslUpmVA=="
     },
     "node_modules/@blues-inc/notehub-js": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/@blues-inc/notehub-js/-/notehub-js-1.0.19.tgz",
-      "integrity": "sha512-lcL9o9wIg+uYGCpODkdh3lJ9Z6GAK4hOptRrhQP6LdTWQkxQAeYPwZrCVdy2m03p4Dax5A4X3AepHJ4O0KZNYg==",
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@blues-inc/notehub-js/-/notehub-js-1.0.22.tgz",
+      "integrity": "sha512-V9Vnj1dXYiieqvDglBMQNPr/QbQFxNsROUbUoiwHuRkBE7h7wNJd4XmG1tTjfLaamObGnudQdD5wkyoS91YeYw==",
       "dependencies": {
         "@babel/cli": "^7.0.0",
         "querystring": "^0.2.1",
@@ -9238,9 +9238,9 @@
       "integrity": "sha512-ZP/k3lbIB97aJDY5rUK61++RvKABNuK+iek0J2ucAL5h3BOSlU2FyODf2fD49eESnBYIUSxmKU25S3XslUpmVA=="
     },
     "@blues-inc/notehub-js": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/@blues-inc/notehub-js/-/notehub-js-1.0.19.tgz",
-      "integrity": "sha512-lcL9o9wIg+uYGCpODkdh3lJ9Z6GAK4hOptRrhQP6LdTWQkxQAeYPwZrCVdy2m03p4Dax5A4X3AepHJ4O0KZNYg==",
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@blues-inc/notehub-js/-/notehub-js-1.0.22.tgz",
+      "integrity": "sha512-V9Vnj1dXYiieqvDglBMQNPr/QbQFxNsROUbUoiwHuRkBE7h7wNJd4XmG1tTjfLaamObGnudQdD5wkyoS91YeYw==",
       "requires": {
         "@babel/cli": "^7.0.0",
         "querystring": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@beyonk/svelte-notifications": "^4.2.0",
-    "@blues-inc/notehub-js": "^1.0.17",
+    "@blues-inc/notehub-js": "^1.0.22",
     "chart.js": "^4.4.0",
     "date-fns": "^2.30.0",
     "mapbox-gl": "^2.15.0",

--- a/src/lib/components/charts/AQIChart.svelte
+++ b/src/lib/components/charts/AQIChart.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { format, parseISO } from 'date-fns';
+  import { format } from 'date-fns';
   import { DATE_TIME_FORMAT_KEY } from '$lib/constants';
   import Chart, {
     type ChartConfiguration,
@@ -21,7 +21,7 @@
 
   function getAQIData(readings: AirnoteReading[]) {
     aqiData = readings.map((reading) => {
-      const d = parseISO(reading.captured);
+      const d = reading.captured * 1000;
       return {
         x: format(d, DATE_TIME_FORMAT_KEY),
         y: reading.aqi

--- a/src/lib/components/charts/HumidityChart.svelte
+++ b/src/lib/components/charts/HumidityChart.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { format, parseISO } from 'date-fns';
+  import { format } from 'date-fns';
   import { DATE_TIME_FORMAT_KEY } from '$lib/constants';
   import Chart, {
     type ChartConfiguration,
@@ -21,7 +21,7 @@
 
   function getHumidityData(readings: AirnoteReading[]) {
     humidityData = readings.map((reading) => {
-      const d = parseISO(reading.captured);
+      const d = reading.captured * 1000;
       return {
         x: format(d, DATE_TIME_FORMAT_KEY),
         y: reading.humidity

--- a/src/lib/components/charts/PMChart.svelte
+++ b/src/lib/components/charts/PMChart.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { format, parseISO } from 'date-fns';
+  import { format } from 'date-fns';
   import { DATE_TIME_FORMAT_KEY } from '$lib/constants';
   import Chart, {
     type ChartConfiguration,
@@ -23,11 +23,8 @@
   }
 
   function getPMData(readings: AirnoteReading[]) {
-    /* reading.captured comes in as something like 2022-08-22T06:27:38Z, 
-    then parseISO() turns it into Mon Aug 22 2022 02:27:38 GMT-0400 (Eastern Daylight Time),
-    and we take that date object and format() for the particular component (MM-dd HH:mm) */
     pm1Data = readings.map((reading) => {
-      const d = parseISO(reading.captured);
+      const d = reading.captured * 1000;
       return {
         x: format(d, DATE_TIME_FORMAT_KEY),
         y: reading.pm01_0
@@ -36,7 +33,7 @@
       };
     });
     pm2_5Data = readings.map((reading) => {
-      const d = parseISO(reading.captured);
+      const d = reading.captured * 1000;
       return {
         x: format(d, DATE_TIME_FORMAT_KEY),
         y: reading.pm02_5
@@ -45,7 +42,7 @@
       };
     });
     pm10Data = readings.map((reading) => {
-      const d = parseISO(reading.captured);
+      const d = reading.captured * 1000;
       return {
         x: format(d, DATE_TIME_FORMAT_KEY),
         y: reading.pm10_0

--- a/src/lib/components/charts/TempChart.svelte
+++ b/src/lib/components/charts/TempChart.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount, createEventDispatcher } from 'svelte';
-  import { format, parseISO } from 'date-fns';
+  import { format } from 'date-fns';
   import { toFahrenheit } from '../../services/air';
   import { DATE_TIME_FORMAT_KEY } from '../../constants';
   import Chart, {
@@ -26,7 +26,7 @@
 
   function getTempData(readings: AirnoteReading[]) {
     tempDataCelsius = readings.map((reading) => {
-      const d = parseISO(reading.captured);
+      const d = reading.captured * 1000;
       return {
         x: format(d, DATE_TIME_FORMAT_KEY),
         y: reading.temperature
@@ -35,7 +35,7 @@
       };
     });
     tempDataFahrenheit = readings.map((reading) => {
-      const d = parseISO(reading.captured);
+      const d = reading.captured * 1000;
       return {
         x: format(d, DATE_TIME_FORMAT_KEY),
         y: reading.temperature

--- a/src/lib/components/charts/VoltageChart.svelte
+++ b/src/lib/components/charts/VoltageChart.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { format, parseISO } from 'date-fns';
+  import { format } from 'date-fns';
   import { DATE_TIME_FORMAT_KEY } from '$lib/constants';
   import Chart, {
     type ChartConfiguration,
@@ -27,7 +27,7 @@
 
   function getVoltageData(readings: AirnoteReading[]) {
     voltageData = readings.reverse().map((reading) => {
-      const d = parseISO(reading.captured);
+      const d = reading.captured * 1000;
       return {
         x: format(d, DATE_TIME_FORMAT_KEY),
         y: reading.voltage
@@ -38,7 +38,7 @@
     chargingData = readings
       .filter((reading) => reading.charging)
       .map((reading) => {
-        const d = parseISO(reading.captured);
+        const d = reading.captured * 1000;
         return {
           x: format(d, DATE_TIME_FORMAT_KEY),
           y: MAX_VOLTAGE,

--- a/src/lib/services/AirReadingModel.ts
+++ b/src/lib/services/AirReadingModel.ts
@@ -7,7 +7,7 @@ export interface AirnoteReading {
   c01_00: number;
   c02_50: number;
   c05_00: number;
-  captured: string;
+  captured: number;
   charging?: boolean;
   csamples: number;
   csecs: number;

--- a/src/lib/services/NotehubEventModel.ts
+++ b/src/lib/services/NotehubEventModel.ts
@@ -1,15 +1,15 @@
 export interface NotehubEvent {
   body: NotehubEventBody;
   heatIndex: number;
-  lat: number;
-  location: string;
-  lon: number;
+  best_lat: number;
+  best_location: string;
+  best_lon: number;
   serial_number: string;
-  when: string;
+  when: number;
 }
 
 interface NotehubEventBody {
-  captured: string;
+  captured: number;
   location: string;
   lat: number;
   lon: number;

--- a/src/lib/services/device.ts
+++ b/src/lib/services/device.ts
@@ -11,7 +11,10 @@ export function getHistoryReadings(readings: AirnoteReading[]) {
   const groupedReadings: Record<string, AirnoteReading[]> = {};
 
   readings.forEach((reading) => {
-    const formattedDate = format(new Date(reading.captured), DATE_FORMAT_KEY);
+    const formattedDate = format(
+      new Date(reading.captured * 1000),
+      DATE_FORMAT_KEY
+    );
     if (groupedReadings[formattedDate]) {
       groupedReadings[formattedDate].push(reading);
     } else {
@@ -56,9 +59,9 @@ export function getCurrentReadings(events: NotehubEvent[], deviceUID: string) {
     const data: AirnoteReading = event.body;
     data.device_uid = deviceUID;
     data.captured = event.when;
-    data.location = event.location;
-    data.lat = event.lat;
-    data.lon = event.lon;
+    data.location = event.best_location;
+    data.lat = event.best_lat;
+    data.lon = event.best_lon;
     data.serial_number = event.serial_number;
     data.aqi = event.body.aqi ? event.body.aqi : 0;
     data.pm01_0 = event.body.pm01_0 ? event.body.pm01_0 : 0;

--- a/src/lib/services/notehub.ts
+++ b/src/lib/services/notehub.ts
@@ -1,11 +1,13 @@
 import * as NotehubJs from '@blues-inc/notehub-js';
 import { HUB_AUTH_TOKEN } from '$env/static/private';
+import { convertToSeconds } from '$lib/util/dates';
 import type { DeviceEnvVars } from './DeviceEnvVarModel';
 
 const AIRNOTE_PROJECT_UID = 'app:2606f411-dea6-44a0-9743-1130f57d77d8';
 
 const notehubJsClient = NotehubJs.ApiClient.instance;
 const deviceApiInstance = new NotehubJs.DeviceApi();
+const eventApiInstance = new NotehubJs.EventApi();
 
 // read env vars only
 export async function getDeviceEnvironmentVariables(deviceUID: string) {
@@ -82,30 +84,31 @@ export async function updateDeviceEnvironmentVariablesByPin(
 }
 
 // get events from Airnote project in Notehub
-export async function getEvents(deviceUID: string, timeframe = '30 days') {
+export async function getEvents(deviceUID: string, timeframe = 30) {
   /* this function is fetched on mount with 30 days' worth of data to
 		  populate the CSV download, the AQI average history AND
 		  display today's most current reading as well */
+  const { api_key } = notehubJsClient.authentications;
+  api_key.apiKey = HUB_AUTH_TOKEN;
 
-  const body = {
-    req: 'hub.app.data.query',
-    query: {
-      columns:
-        ".body;.when;lat:(events.value->'best_lat');lon:(events.value->'best_lon');location:(events.value->'best_location')",
-      limit: 10000,
-      order: '.modified',
-      descending: true,
-      where: `.file::text='_air.qo' and .device::text='${deviceUID}' and .modified >= now()-interval '${timeframe}'`
-    }
+  // todo refactor this
+  // convert timeframe into two dates
+  const endDateMs = new Date().getTime();
+  const endDateSecs = convertToSeconds(endDateMs);
+  const startDateMs = new Date(
+    endDateMs - timeframe * 24 * 60 * 60 * 1000
+  ).getTime();
+  const startDateSecs = convertToSeconds(startDateMs);
+
+  const opts = {
+    deviceUID: [deviceUID],
+    sortBy: 'modified',
+    sortOrder: 'desc',
+    files: '_air.qo',
+    startDate: startDateSecs,
+    endDate: endDateSecs,
+    pageSize: 10000
   };
 
-  const res = await fetch(
-    `https://api.notefile.net/req?app=${AIRNOTE_PROJECT_UID}`,
-    {
-      method: 'POST',
-      body: JSON.stringify(body)
-    }
-  );
-
-  return res.json();
+  return await eventApiInstance.getProjectEvents(AIRNOTE_PROJECT_UID, opts);
 }

--- a/src/lib/services/notehub.ts
+++ b/src/lib/services/notehub.ts
@@ -84,12 +84,14 @@ export async function updateDeviceEnvironmentVariablesByPin(
 }
 
 // get events from Airnote project in Notehub
-export async function getEvents(deviceUID: string, timeframe = 30) {
+export async function getEvents(
+  deviceUID: string,
+  timeframe = 30,
+  includeAllFields = false
+) {
   /* this function is fetched on mount with 30 days' worth of data to
 		  populate the CSV download, the AQI average history AND
 		  display today's most current reading as well */
-  const { api_key } = notehubJsClient.authentications;
-  api_key.apiKey = HUB_AUTH_TOKEN;
 
   // convert timeframe into seconds for start and end date
   const { startDateSecs, endDateSecs } = convertTimeframeToSeconds(timeframe);
@@ -101,8 +103,15 @@ export async function getEvents(deviceUID: string, timeframe = 30) {
     files: '_air.qo',
     startDate: startDateSecs,
     endDate: endDateSecs,
-    pageSize: 10000
+    pageSize: 10000,
+    selectFields: ''
   };
+
+  // todo once the bug is fixed, remove entire body from selected fields and just add needed properties
+  if (!includeAllFields) {
+    opts.selectFields =
+      'when,best_location,best_lat,best_lon,serial_number,body';
+  }
 
   return await eventApiInstance.getProjectEvents(AIRNOTE_PROJECT_UID, opts);
 }

--- a/src/lib/services/notehub.ts
+++ b/src/lib/services/notehub.ts
@@ -1,6 +1,6 @@
 import * as NotehubJs from '@blues-inc/notehub-js';
 import { HUB_AUTH_TOKEN } from '$env/static/private';
-import { convertToSeconds } from '$lib/util/dates';
+import { convertTimeframeToSeconds } from '$lib/util/dates';
 import type { DeviceEnvVars } from './DeviceEnvVarModel';
 
 const AIRNOTE_PROJECT_UID = 'app:2606f411-dea6-44a0-9743-1130f57d77d8';
@@ -91,14 +91,8 @@ export async function getEvents(deviceUID: string, timeframe = 30) {
   const { api_key } = notehubJsClient.authentications;
   api_key.apiKey = HUB_AUTH_TOKEN;
 
-  // todo refactor this
-  // convert timeframe into two dates
-  const endDateMs = new Date().getTime();
-  const endDateSecs = convertToSeconds(endDateMs);
-  const startDateMs = new Date(
-    endDateMs - timeframe * 24 * 60 * 60 * 1000
-  ).getTime();
-  const startDateSecs = convertToSeconds(startDateMs);
+  // convert timeframe into seconds for start and end date
+  const { startDateSecs, endDateSecs } = convertTimeframeToSeconds(timeframe);
 
   const opts = {
     deviceUID: [deviceUID],

--- a/src/lib/util/dates.ts
+++ b/src/lib/util/dates.ts
@@ -33,6 +33,20 @@ export function filterEventsByDate(
   return events.filter((event) => isAfter(event.captured * 1000, startingDate));
 }
 
-export function convertToSeconds(millisecondsTimestamp: number) {
+function convertToSeconds(millisecondsTimestamp: number) {
   return Math.floor(millisecondsTimestamp / 1000);
+}
+
+export function convertTimeframeToSeconds(timeframe: number) {
+  const endDateMs = new Date().getTime();
+  const endDateSecs = convertToSeconds(endDateMs);
+  const startDateMs = new Date(
+    endDateMs - timeframe * 24 * 60 * 60 * 1000
+  ).getTime();
+  const startDateSecs = convertToSeconds(startDateMs);
+
+  return {
+    endDateSecs,
+    startDateSecs
+  };
 }

--- a/src/lib/util/dates.ts
+++ b/src/lib/util/dates.ts
@@ -1,6 +1,6 @@
 import DATE_RANGE_OPTIONS from '$lib/constants/DateRangeOptions';
 import type { AirnoteReading } from '$lib/services/AirReadingModel';
-import { isAfter, subDays, parseISO } from 'date-fns';
+import { isAfter, subDays } from 'date-fns';
 
 interface DateRangeOption {
   [key: string]: number;
@@ -30,7 +30,9 @@ export function filterEventsByDate(
 ) {
   const startingDate = subDays(new Date(), daysPrior);
   // Filter out any events that occurred before the starting date
-  return events.filter((event) =>
-    isAfter(parseISO(event.captured), startingDate)
-  );
+  return events.filter((event) => isAfter(event.captured * 1000, startingDate));
+}
+
+export function convertToSeconds(millisecondsTimestamp: number) {
+  return Math.floor(millisecondsTimestamp / 1000);
 }

--- a/src/routes/[deviceUID]/dashboard/+page.server.ts
+++ b/src/routes/[deviceUID]/dashboard/+page.server.ts
@@ -30,7 +30,7 @@ export async function load({ params }) {
     .then((responses) => {
       const [envVarResponse, eventsResponse] = responses;
       const serialNumber = envVarResponse.environment_variables._sn;
-      allEvents.push(...eventsResponse);
+      allEvents.push(...eventsResponse.events);
       allEvents.forEach((entry) => (entry.serial_number = serialNumber));
       readings = getCurrentReadings(allEvents, deviceUID);
       history = getHistoryReadings(readings);

--- a/src/routes/[deviceUID]/dashboard/+page.svelte
+++ b/src/routes/[deviceUID]/dashboard/+page.svelte
@@ -156,7 +156,10 @@
       <p class="last-update">
         Last Update:
         <span>
-          {format(new Date(lastReading.captured), "MMMM dd yyyy 'at' h:mm aaa")}
+          {format(
+            new Date(lastReading.captured * 1000),
+            "MMMM dd yyyy 'at' h:mm aaa"
+          )}
         </span>
       </p>
       <div class="box speedometer-box">

--- a/src/routes/[deviceUID]/dashboard/MapboxMap.svelte
+++ b/src/routes/[deviceUID]/dashboard/MapboxMap.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { format, parseISO } from 'date-fns';
+  import { format } from 'date-fns';
   import { aqiColors, aqiRanges, getAQIColor } from '$lib/services/air';
   import { DATE_TIME_KEY } from '$lib/constants';
   import mapboxgl from 'mapbox-gl';
@@ -48,7 +48,7 @@
       }
     });
 
-    const d = parseISO(lastReading.captured);
+    const d = lastReading.captured * 1000;
 
     popup = new mapboxgl.Popup().setHTML(
       `<p style="text-align: center; margin:0">${format(d, DATE_TIME_KEY)}</p>

--- a/src/routes/api/download/+server.ts
+++ b/src/routes/api/download/+server.ts
@@ -17,12 +17,12 @@ export async function GET({ url }) {
 
   await Promise.all([
     getDeviceEnvironmentVariables(deviceUID),
-    getEvents(deviceUID, '90 days')
+    getEvents(deviceUID, 90)
   ])
     .then((responses) => {
       const [envVarResponse, eventsResponse] = responses;
       const serialNumber = envVarResponse.environment_variables._sn;
-      allEvents.push(...eventsResponse);
+      allEvents.push(...eventsResponse.events);
       allEvents.forEach((entry) => (entry.serial_number = serialNumber));
       readings = getCurrentReadings(allEvents, deviceUID);
     })

--- a/src/routes/api/download/+server.ts
+++ b/src/routes/api/download/+server.ts
@@ -17,7 +17,7 @@ export async function GET({ url }) {
 
   await Promise.all([
     getDeviceEnvironmentVariables(deviceUID),
-    getEvents(deviceUID, 90)
+    getEvents(deviceUID, 90, true)
   ])
     .then((responses) => {
       const [envVarResponse, eventsResponse] = responses;


### PR DESCRIPTION
# Problem Context

An investigation into the use of our non-standard Notehub APIs has caused issues for the Airnote project, and we need to stabilize it and bring it into alignment with our current v1 APIs if possible.

As I looked into the v0 `getEvents()` query, I decided to have a go with using the (newly enhanced) Notehub JS `getEvents()` function (it has lots more query params to narrow down which events are returned), and by jove it worked well.

## Changes

* Replace Notehub API v0 `getEvents()` query with official Notehub JS SDK `getEvents()` query.
* Refactor date parsing on frontend to ensure unix timestamp dates from Notehub SDK are interpreted correctly (as opposed to ISO dates which came from v0 API)

## Screenshot (if applicable)

Site appearance remains unchanged.

## Testing

Unit / integration / e2e tests?

All tests pass 

Steps to test manually?

1. Go to a particularly event-heavy Airnote dashboard like: `http://localhost:5173/dev:863740067288636/dashboard`
2. See that it loads the page up snappily
3. Check out the tables and charts and make sure the dates look right
4. Download the CSV and see that 90 days' worth of data is there
5. Compare to the same dashboard in prod to view loading times, CSV download, etc. and make sure it all looks the same (it should)

Any other sorts of testing notes to include?

## Any other related PRs

n/a

## Ticket(s)

https://bluesinc.atlassian.net/jira/software/c/projects/BLUESDEV/boards/13?selectedIssue=BLUESDEV-400
