### PR TITLE
chore: quiet error logging for invalid device IDs

### DIFF
--- a/src/lib/services/notehub.ts
+++ b/src/lib/services/notehub.ts
@@ -5,7 +5,7 @@ import type { DeviceEnvVars } from './DeviceEnvVarModel';
 
 const AIRNOTE_PROJECT_UID = 'app:2606f411-dea6-44a0-9743-1130f57d77d8';
 
-function isValidDeviceUID(deviceUID: string) {
+export function isValidDeviceUID(deviceUID: string) {
   const validPrefixes = ['dev:', 'imei:', 'test:', 'id:'];
   return validPrefixes.some((prefix) => deviceUID.startsWith(prefix));
 }
@@ -17,7 +17,10 @@ const eventApiInstance = new NotehubJs.EventApi();
 // read env vars only
 export async function getDeviceEnvironmentVariables(deviceUID: string) {
   if (!isValidDeviceUID(deviceUID)) {
-    throw new Error('Invalid device UID. getDeviceEnvVar() API call aborted.');
+    console.warn(
+      `Invalid device UID ${deviceUID}. Skipping getDeviceEnvVar() API call.`
+    );
+    return null;
   }
 
   const { api_key } = notehubJsClient.authentications;
@@ -34,7 +37,9 @@ export async function getDeviceEnvironmentVariablesByPin(
   pinNumber: string
 ) {
   if (!isValidDeviceUID(deviceUID)) {
-    throw new Error('Invalid device UID');
+    console.warn(
+      `Invalid device UID ${deviceUID}. Skipping getDeviceEnvVar() API call.`
+    );
   }
 
   const { pin } = notehubJsClient.authentications;
@@ -48,8 +53,8 @@ export async function getDeviceEnvironmentVariablesByPin(
 // delete env var by key on device
 async function deleteDeviceEnvironmentVariable(deviceUID: string, key: string) {
   if (!isValidDeviceUID(deviceUID)) {
-    throw new Error(
-      'Invalid device UID. deleteDeviceEnvVar() API call aborted.'
+    console.warn(
+      `Invalid device UID ${deviceUID}. Skipping deleteDeviceEnvVar() API call.`
     );
   }
 
@@ -69,7 +74,9 @@ async function putDeviceEnvironmentVariablesByPin(
   environmentVariables: DeviceEnvVars
 ) {
   if (!isValidDeviceUID(deviceUID)) {
-    throw new Error('Invalid device UID. putDeviceEnvVar() API call aborted.');
+    console.warn(
+      `Invalid device UID ${deviceUID}. Skipping putDeviceEnvVar() API.`
+    );
   }
 
   const { pin } = notehubJsClient.authentications;
@@ -90,8 +97,8 @@ export async function updateDeviceEnvironmentVariablesByPin(
   environmentVariables: DeviceEnvVars
 ) {
   if (!isValidDeviceUID(deviceUID)) {
-    throw new Error(
-      'Invalid device UID. updateDeviceEnvVar() API call aborted.'
+    console.warn(
+      `Invalid device UID ${deviceUID}. Skipping updateDeviceEnvVar() API call.`
     );
   }
   // If the _air_mins environment variable is set to the default, don't save the value so
@@ -118,7 +125,9 @@ export async function getEvents(
   includeAllFields = false
 ) {
   if (!isValidDeviceUID(deviceUID)) {
-    throw new Error('Invalid device UID. getEvents() API call aborted.');
+    console.warn(
+      `Invalid device UID ${deviceUID}. Skipping getEvents() API call.`
+    );
   }
   /* this function is fetched on mount with 30 days' worth of data to
 		  populate the CSV download, the AQI average history AND

--- a/src/routes/[deviceUID]/dashboard/+page.server.ts
+++ b/src/routes/[deviceUID]/dashboard/+page.server.ts
@@ -1,7 +1,8 @@
 import { error } from '@sveltejs/kit';
 import {
   getDeviceEnvironmentVariables,
-  getEvents
+  getEvents,
+  isValidDeviceUID
 } from '$lib/services/notehub';
 import { getCurrentReadings, getHistoryReadings } from '$lib/services/device';
 import type { NotehubEvent } from '$lib/services/NotehubEventModel';
@@ -19,6 +20,14 @@ export async function load({ params }) {
     pm2_5: {},
     pm10_0: {}
   };
+
+  if (!isValidDeviceUID(deviceUID)) {
+    error(400, {
+      message: 'Invalid device UID',
+      errorType: ERROR_TYPE.NOTEHUB_ERROR,
+      deviceUID
+    });
+  }
 
   let erred = false;
   let notehubError: { status: number } | undefined;

--- a/src/routes/api/download/+server.ts
+++ b/src/routes/api/download/+server.ts
@@ -1,19 +1,31 @@
 import pkg from 'papaparse';
 import {
   getEvents,
-  getDeviceEnvironmentVariables
+  getDeviceEnvironmentVariables,
+  isValidDeviceUID
 } from '$lib/services/notehub.js';
 import { getCurrentReadings } from '$lib/services/device';
+import { ERROR_TYPE } from '$lib/constants/ErrorTypes.js';
 import type { NotehubEvent } from '$lib/services/NotehubEventModel.js';
 import type { AirnoteReading } from '$lib/services/AirReadingModel.js';
 
 const { unparse } = pkg;
 
 export async function GET({ url }) {
+  const deviceUID = String(url.searchParams.get('deviceUID'));
+
+  if (!isValidDeviceUID(deviceUID)) {
+    return new Response(
+      JSON.stringify({
+        message: `Invalid device UID: ${deviceUID}`,
+        errorType: ERROR_TYPE.NOTEHUB_ERROR
+      }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
   const allEvents: NotehubEvent[] = [];
   let readings: AirnoteReading[] = [];
-
-  const deviceUID = String(url.searchParams.get('deviceUID'));
 
   await Promise.all([
     getDeviceEnvironmentVariables(deviceUID),


### PR DESCRIPTION
# Problem Context

In an effort to limit bad actors trying to hit the Notehub API with junk requests, I implemented error handling to log every time a bad device ID was passed to the API and abort the call before it happened.

This caused a lot of messages of invalid device IDs and errors to show up in our logs. This needs to be quieted down and even validate the inputs earlier when possible to reduce unnecessary function executions.

## Changes

* Change all throw Error validations into console.warn instead
* Add validation of device IDs to pages where API functions are originally invoked to cut down even further of function calls

## Screenshot (if applicable)

## Testing

Unit / integration / e2e tests?

All tests still pass.

Steps to test manually?

Any other sorts of testing notes to include?

## Any other related PRs

n/a

## Ticket(s)

https://bluesinc.atlassian.net/jira/software/c/projects/BLUESDEV/boards/13?selectedIssue=BLUESDEV-441
