### PR TITLE
chore: adjust text for indoor devices

### DIFF
--- a/src/routes/[deviceUID]/DeviceSettings.svelte
+++ b/src/routes/[deviceUID]/DeviceSettings.svelte
@@ -77,7 +77,11 @@
         name="indoorDevice"
         id="indoorDevice"
       />
-      <span>Private device (Will not be visible on the global map)</span>
+      <span
+        >Indoor device (Will omit device data and location from <a
+          href="https://map.safecast.org">global Safecast map</a
+        >)</span
+      >
     </label>
   </div>
 

--- a/src/routes/[deviceUID]/DeviceSettings.svelte
+++ b/src/routes/[deviceUID]/DeviceSettings.svelte
@@ -78,8 +78,9 @@
         id="indoorDevice"
       />
       <span
-        >Indoor device (Will omit device data and location from <a
-          href="https://map.safecast.org">global Safecast map</a
+        >Indoor device (Omits device air quality readings and location from
+        external providers, such as <a href="https://map.safecast.org"
+          >Safecast</a
         >)</span
       >
     </label>

--- a/src/routes/[deviceUID]/Slider.svelte
+++ b/src/routes/[deviceUID]/Slider.svelte
@@ -63,8 +63,10 @@
   />
   <output class="frequencyPopup" />
 </div>
-<span class="min-val">15 min</span>
-<span class="max-val">1440 min</span>
+<div class="frequencySliderVals">
+  <span class="min-val">15 min</span>
+  <span class="max-val">1440 min</span>
+</div>
 
 <style>
   .frequency-wrap {
@@ -124,11 +126,14 @@
     right: 15%;
   }
 
-  .min-val,
-  .max-val {
-    color: var(--medGrey);
-  }
-  .max-val {
-    float: right;
+  .frequencySliderVals {
+    display: flex;
+    justify-content: space-between;
+
+    & .min-val,
+    .max-val {
+      color: var(--medGrey);
+      margin-bottom: 16px;
+    }
   }
 </style>

--- a/src/routes/[deviceUID]/dashboard/+page.server.ts
+++ b/src/routes/[deviceUID]/dashboard/+page.server.ts
@@ -14,7 +14,6 @@ export async function load({ params }) {
   const deviceUID = params.deviceUID;
   const allEvents: NotehubEvent[] = [];
   let readings: AirnoteReading[] = [];
-  let isIndoors = false;
   let history: AirnoteHistoryReadings = {
     aqi: {},
     pm1_0: {},
@@ -40,9 +39,6 @@ export async function load({ params }) {
     .then((responses) => {
       const [envVarResponse, eventsResponse] = responses;
       const serialNumber = envVarResponse.environment_variables._sn;
-      if (envVarResponse.environment_variables._air_indoors === '1') {
-        isIndoors = true;
-      }
       allEvents.push(...eventsResponse.events);
       allEvents.forEach((entry) => (entry.serial_number = serialNumber));
       readings = getCurrentReadings(allEvents, deviceUID);
@@ -73,8 +69,7 @@ export async function load({ params }) {
   } else {
     return {
       readings,
-      history,
-      isIndoors
+      history
     };
   }
 }

--- a/src/routes/[deviceUID]/dashboard/+page.svelte
+++ b/src/routes/[deviceUID]/dashboard/+page.svelte
@@ -33,8 +33,6 @@
   import { getNotehubEventsUrl } from '$lib/util/url';
 
   export let deviceUID: string;
-  let productUID: string;
-  let pin: string;
 
   let lastReading: AirnoteReading;
   let readings: AirnoteReading[] = [];
@@ -45,7 +43,6 @@
     pm10_0: {}
   };
   let displayedReadings: AirnoteReading[];
-  let hideMap = false;
 
   let error = false;
   let errorType: string;
@@ -72,10 +69,6 @@
 
   if (data && data.history) {
     history = data.history;
-  }
-
-  if (data && data.isIndoors) {
-    hideMap = true;
   }
 
   if (!readings || readings.length === 0) {
@@ -121,8 +114,6 @@
   onMount(() => {
     const currentDevice: AirnoteDevice = getCurrentDeviceFromUrl(location);
     deviceUID = currentDevice.deviceUID ? currentDevice.deviceUID : '';
-    productUID = currentDevice.productUID || '';
-    pin = currentDevice.pin || '';
     tempDisplay = localStorage.getItem('tempDisplay') || 'C';
     showBanner = localStorage.getItem('showBanner') === 'false' ? false : true;
   });
@@ -288,22 +279,9 @@
         </a>
       </p>
 
-      {#if !hideMap}
-        <div class="map">
-          <MapboxMap {lastReading} />
-        </div>
-      {:else}
-        <div class="banner">
-          <p>
-            Not seeing your device on the map? Check the 
-            <a href="/{deviceUID}?product={productUID}&pin={pin}&internalNav=true">settings page</a> 
-            to verify the device is not set to Private.
-          </p>
-          <button class="svg-button" style="display: none;">
-            <CloseIcon />
-          </button>
-        </div>
-      {/if}
+      <div class="map">
+        <MapboxMap {lastReading} />
+      </div>
     </div>
 
     <div class="box">


### PR DESCRIPTION
# Problem Context

Per internal discussions, revert the map view of the Airnote devices to display even when they are set to indoors. And provide extra context to help users understand what it means to set a device to "indoors".

## Changes

* Undo logic to show/hide map based on device's `_air_indoors` environment variable setting.
* Add clarifying text to "Indoors" checkbox in device settings page to better clarify what it means to set a device to "indoors" status.

## Screenshot (if applicable)

![Screenshot 2025-02-04 at 9 35 02 AM](https://github.com/user-attachments/assets/c4a1e2d6-8168-499c-9790-cd6a60b4025c)

## Testing

Unit / integration / e2e tests?

All tests pass 

Steps to test manually?
Any other sorts of testing notes to include?

## Any other related PRs

n/a

## Ticket(s)
