### PR TITLE
bug: adjust Notehub URL to filter to events for certain device [HUB-916]

### DIFF
--- a/src/lib/util/url.ts
+++ b/src/lib/util/url.ts
@@ -6,6 +6,12 @@ export function getPathname() {
   return decodeURIComponent(location.pathname);
 }
 
+// remove the "dev:" prefix from the DeviceUID.
+export function getDeviceUID(deviceUID: string) {
+  return deviceUID.replace('dev:', '');
+}
+
 export function getNotehubEventsUrl(deviceUID: string) {
-  return `https://notehub.io/project/${APP_UID}/events?filter_dev=${deviceUID}`;
+  const deviceNumber = getDeviceUID(deviceUID);
+  return `https://notehub.io/project/${APP_UID}/events?filter_dev=${deviceNumber}`;
 }

--- a/src/lib/util/url.ts
+++ b/src/lib/util/url.ts
@@ -6,7 +6,7 @@ export function getPathname() {
   return decodeURIComponent(location.pathname);
 }
 
-// remove the "dev:" prefix from the DeviceUID.
+// remove the "dev:" prefix from the DeviceUID. (Required for filtering Notehub events correctly when exporting data after being redirected to Notehub)
 export function getDeviceUID(deviceUID: string) {
   return deviceUID.replace('dev:', '');
 }


### PR DESCRIPTION
# Problem Context

A customer was unable to export data from their Airnotes in the Notehub UI.  When the Export button is used, it downloads a 0 KB file.

The issue stems from a malformed URL filter that directs a user from the Airnote dashboard to the Notehub UI that displays just that particular device's events.

## Changes

* Adjust the `getNotehubEventsUrl()` function to strip down the supplied deviceUID which includes the prefix of `dev:` to just the bare numbers before passing to the URL string

## Screenshot (if applicable)

Prod (broken URL redirect)

![Screenshot 2025-03-04 at 2 45 10 PM](https://github.com/user-attachments/assets/2346223a-37f5-4565-ac0f-0a2176a8811d)

Local version (fixed URL redirect)

![Screenshot 2025-03-04 at 2 45 01 PM](https://github.com/user-attachments/assets/50fede78-b4f5-4739-9020-7849bba3d2a6)

## Testing

Unit / integration / e2e tests?

All tests pass 

Steps to test manually?

1. Go to http://localhost:5173/dev:864475044215258/dashboard
2. Click on the `View live Airnote events on Notehub.io` link below the current readings section of the dashboard
3. See it correctly redirect to the Notehub UI, including the device filter in the UI's filter bar
4. Click the export button and export all data related to that device from Notehub successfully

Any other sorts of testing notes to include?

## Any other related PRs

n/a

## Ticket(s)

https://bluesinc.atlassian.net/browse/HUB-916
