### PR TITLE
bug: update the device env var by pin APIs to use productIDs going forward [BLUESDEV-457]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@beyonk/svelte-notifications": "^4.2.0",
-        "@blues-inc/notehub-js": "^1.0.22",
+        "@blues-inc/notehub-js": "^1.0.29",
         "chart.js": "^4.4.0",
         "date-fns": "^2.30.0",
         "mapbox-gl": "^2.15.0",
@@ -401,9 +401,10 @@
       "integrity": "sha512-ZP/k3lbIB97aJDY5rUK61++RvKABNuK+iek0J2ucAL5h3BOSlU2FyODf2fD49eESnBYIUSxmKU25S3XslUpmVA=="
     },
     "node_modules/@blues-inc/notehub-js": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@blues-inc/notehub-js/-/notehub-js-1.0.22.tgz",
-      "integrity": "sha512-V9Vnj1dXYiieqvDglBMQNPr/QbQFxNsROUbUoiwHuRkBE7h7wNJd4XmG1tTjfLaamObGnudQdD5wkyoS91YeYw==",
+      "version": "1.0.29",
+      "resolved": "https://registry.npmjs.org/@blues-inc/notehub-js/-/notehub-js-1.0.29.tgz",
+      "integrity": "sha512-EHlxE0zkuK1GIRAQYAVTdf2RXDjumdcqIjJqJAqXHWahuiFMi9VanbEZPvREZAO6XLxIOGYckTExDz+Yn8R6Iw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/cli": "^7.0.0",
         "querystring": "^0.2.1",
@@ -9238,9 +9239,9 @@
       "integrity": "sha512-ZP/k3lbIB97aJDY5rUK61++RvKABNuK+iek0J2ucAL5h3BOSlU2FyODf2fD49eESnBYIUSxmKU25S3XslUpmVA=="
     },
     "@blues-inc/notehub-js": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@blues-inc/notehub-js/-/notehub-js-1.0.22.tgz",
-      "integrity": "sha512-V9Vnj1dXYiieqvDglBMQNPr/QbQFxNsROUbUoiwHuRkBE7h7wNJd4XmG1tTjfLaamObGnudQdD5wkyoS91YeYw==",
+      "version": "1.0.29",
+      "resolved": "https://registry.npmjs.org/@blues-inc/notehub-js/-/notehub-js-1.0.29.tgz",
+      "integrity": "sha512-EHlxE0zkuK1GIRAQYAVTdf2RXDjumdcqIjJqJAqXHWahuiFMi9VanbEZPvREZAO6XLxIOGYckTExDz+Yn8R6Iw==",
       "requires": {
         "@babel/cli": "^7.0.0",
         "querystring": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@beyonk/svelte-notifications": "^4.2.0",
-    "@blues-inc/notehub-js": "^1.0.22",
+    "@blues-inc/notehub-js": "^1.0.29",
     "chart.js": "^4.4.0",
     "date-fns": "^2.30.0",
     "mapbox-gl": "^2.15.0",

--- a/src/lib/services/notehub.ts
+++ b/src/lib/services/notehub.ts
@@ -11,13 +11,10 @@ export function isValidDeviceUID(deviceUID: string) {
 }
 
 export function isValidProductUID(productUID: string) {
-  const validProductUIDs = [
-    'com.blues.airnote',
-    'org.airnote.solar.v1',
-    'org.airnote.solar.rad.v1',
-    'org.airnote.solar.air.v1'
-  ];
-  return validProductUIDs.includes(productUID);
+  const validProductUIDPrefixes = ['com.blues.airnote', 'org.airnote.solar.v1'];
+  return validProductUIDPrefixes.some((prefix) =>
+    productUID.startsWith(prefix)
+  );
 }
 
 const notehubJsClient = NotehubJs.ApiClient.instance;

--- a/src/lib/services/notehub.ts
+++ b/src/lib/services/notehub.ts
@@ -10,6 +10,16 @@ export function isValidDeviceUID(deviceUID: string) {
   return validPrefixes.some((prefix) => deviceUID.startsWith(prefix));
 }
 
+export function isValidProductUID(productUID: string) {
+  const validProductUIDs = [
+    'com.blues.airnote',
+    'org.airnote.solar.v1',
+    'org.airnote.solar.rad.v1',
+    'org.airnote.solar.air.v1'
+  ];
+  return validProductUIDs.includes(productUID);
+}
+
 const notehubJsClient = NotehubJs.ApiClient.instance;
 const deviceApiInstance = new NotehubJs.DeviceApi();
 const eventApiInstance = new NotehubJs.EventApi();
@@ -33,6 +43,7 @@ export async function getDeviceEnvironmentVariables(deviceUID: string) {
 
 // read env vars by pin
 export async function getDeviceEnvironmentVariablesByPin(
+  productUID: string,
   deviceUID: string,
   pinNumber: string
 ) {
@@ -42,10 +53,16 @@ export async function getDeviceEnvironmentVariablesByPin(
     );
   }
 
+  if (!isValidProductUID(productUID)) {
+    console.warn(
+      `Invalid product UID ${productUID}. Skipping getDeviceEnvVar() API call.`
+    );
+  }
+
   const { pin } = notehubJsClient.authentications;
   pin.apiKey = pinNumber;
   return await deviceApiInstance.getDeviceEnvironmentVariablesByPin(
-    AIRNOTE_PROJECT_UID,
+    productUID,
     deviceUID
   );
 }
@@ -69,6 +86,7 @@ async function deleteDeviceEnvironmentVariable(deviceUID: string, key: string) {
 
 // update env vars on device by pin
 async function putDeviceEnvironmentVariablesByPin(
+  productUID: string,
   deviceUID: string,
   pinNumber: string,
   environmentVariables: DeviceEnvVars
@@ -79,19 +97,26 @@ async function putDeviceEnvironmentVariablesByPin(
     );
   }
 
+  if (!isValidProductUID(productUID)) {
+    console.warn(
+      `Invalid product UID ${productUID}. Skipping getDeviceEnvVar() API call.`
+    );
+  }
+
   const { pin } = notehubJsClient.authentications;
   pin.apiKey = pinNumber;
   const deviceEnvironmentVariables = new NotehubJs.EnvironmentVariables(
     environmentVariables
   );
   return await deviceApiInstance.putDeviceEnvironmentVariablesByPin(
-    AIRNOTE_PROJECT_UID,
+    productUID,
     deviceUID,
     deviceEnvironmentVariables
   );
 }
 
 export async function updateDeviceEnvironmentVariablesByPin(
+  productUID: string,
   deviceUID: string,
   pinNumber: string,
   environmentVariables: DeviceEnvVars
@@ -101,6 +126,13 @@ export async function updateDeviceEnvironmentVariablesByPin(
       `Invalid device UID ${deviceUID}. Skipping updateDeviceEnvVar() API call.`
     );
   }
+
+  if (!isValidProductUID(productUID)) {
+    console.warn(
+      `Invalid product UID ${productUID}. Skipping getDeviceEnvVar() API call.`
+    );
+  }
+
   // If the _air_mins environment variable is set to the default, don't save the value so
   // the device defaults to the project-level _air_mins. Also, delete the environment variable
   // on the device in case it already exists.
@@ -112,6 +144,7 @@ export async function updateDeviceEnvironmentVariablesByPin(
     await deleteDeviceEnvironmentVariable(deviceUID, '_air_mins');
   }
   return await putDeviceEnvironmentVariablesByPin(
+    productUID,
     deviceUID,
     pinNumber,
     environmentVariables

--- a/src/lib/services/notehub.ts
+++ b/src/lib/services/notehub.ts
@@ -11,7 +11,11 @@ export function isValidDeviceUID(deviceUID: string) {
 }
 
 export function isValidProductUID(productUID: string) {
-  const validProductUIDPrefixes = ['com.blues.airnote', 'org.airnote.solar.v1'];
+  const validProductUIDPrefixes = [
+    'com.blues.airnote',
+    'org.airnote.solar.v1',
+    'product:org.airnote.solar.air.v1'
+  ];
   return validProductUIDPrefixes.some((prefix) =>
     productUID.startsWith(prefix)
   );


### PR DESCRIPTION
# Problem Context

A user reported they were unable to update their Airnote device settings even though they have the PIN number required to access those settings. Debugging revealed that the Notehub JS API call to get environment variables by PIN now requires a valid product UID instead of a project UID. Adjust the code to account for this new requirement.

## Changes

* Update Notehub JS API calls that deal with PIN numbers to also require valid product UID strings, and add validation function to check that product UID string matches valid prefix pattern
* Update Notehub JS API dependencies to stay current with latest version of Notehub JS library

## Screenshot (if applicable)

n/a

## Testing

Unit / integration / e2e tests?

All tests continue to pass

Steps to test manually?

1. Scan the QR code of an Airnote device to be redirected to its set up page with a PIN number in the URL, which should allow for updating device settings.
2. See that on the production site (airnote.live... even if a valid PIN is present, the settings cannot be updated)
3. Start a local instance of the Airnote project, and go to http://localhost:5173/[URL_string_from_production]
4. Go to the Settings page and see that as long as the PIN is valid for that device the settings can be updated successfully.

Any other sorts of testing notes to include?

## Any other related PRs

n/a

## Ticket(s)

https://bluesinc.atlassian.net/jira/software/c/projects/BLUESDEV/boards/13?selectedIssue=BLUESDEV-457
