### PR TITLE
feat: adding support for routing URLs

### DIFF
--- a/src/lib/services/notehub.ts
+++ b/src/lib/services/notehub.ts
@@ -13,7 +13,7 @@ export function isValidDeviceUID(deviceUID: string) {
 export function isValidProductUID(productUID: string) {
   const validProductUIDPrefixes = [
     'com.blues.airnote',
-    'org.airnote.solar.v1',
+    'product:org.airnote.solar.v1',
     'product:org.airnote.solar.air.v1'
   ];
   return validProductUIDPrefixes.some((prefix) =>

--- a/src/lib/stores/settingsStore.ts
+++ b/src/lib/stores/settingsStore.ts
@@ -9,3 +9,4 @@ export const sampleFrequencyLow = writable('720');
 export const contactName = writable('');
 export const contactEmail = writable('');
 export const contactAffiliation = writable('');
+export const routingUrl = writable('');

--- a/src/routes/[deviceUID]/+page.server.ts
+++ b/src/routes/[deviceUID]/+page.server.ts
@@ -158,7 +158,7 @@ function createEnvVarBody(
   const currentCheckboxState = determineCurrentCheckboxState(formData, envVars);
 
   return {
-    _sn: formData.get('deviceName')
+    _sn: formData.has('deviceName')
       ? formData.get('deviceName')
       : envVars['_sn'],
     _air_mins: formatAirSamplingInterval(formData, envVars),
@@ -166,14 +166,17 @@ function createEnvVarBody(
     _air_status: formData.get('displayValue')
       ? formData.get('displayValue')
       : envVars['_air_status'],
-    _contact_name: formData.get('contactName')
+    _contact_name: formData.has('contactName')
       ? formData.get('contactName')
       : envVars['_contact_name'],
-    _contact_email: formData.get('contactEmail')
+    _contact_email: formData.has('contactEmail')
       ? formData.get('contactEmail')
       : envVars['_contact_email'],
-    _contact_affiliation: formData.get('contactAffiliation')
+    _contact_affiliation: formData.has('contactAffiliation')
       ? formData.get('contactAffiliation')
-      : envVars['_contact_affiliation']
+      : envVars['_contact_affiliation'],
+    _route: formData.has('routingUrl')
+      ? formData.get('routingUrl')
+      : envVars['_route']
   };
 }

--- a/src/routes/[deviceUID]/+page.svelte
+++ b/src/routes/[deviceUID]/+page.svelte
@@ -5,6 +5,7 @@
   import { getCurrentDeviceFromUrl } from '$lib/services/device';
   import DeviceSettings from './DeviceSettings.svelte';
   import DeviceOwner from './DeviceOwner.svelte';
+  import DeviceAdvanced from './DeviceAdvanced.svelte';
   import {
     deviceName,
     displayValue,
@@ -14,7 +15,8 @@
     sampleFrequencyLow,
     contactName,
     contactEmail,
-    contactAffiliation
+    contactAffiliation,
+    routingUrl
   } from '$lib/stores/settingsStore';
   import type {
     AirnoteDevice,
@@ -117,6 +119,7 @@
     if (data['_contact_email']) contactEmail.set(data['_contact_email']);
     if (data['_contact_affiliation'])
       contactAffiliation.set(data['_contact_affiliation']);
+    if (data['_route']) routingUrl.set(data['_route']);
   };
 
   if (data.notehubResponse) {
@@ -191,6 +194,17 @@
 
 <section>
   <DeviceOwner
+    {enableFields}
+    on:settingsSaved={() => handleSettingsSaved()}
+    on:settingsError={() => handleSettingsError()}
+    {pin}
+  />
+</section>
+
+<hr />
+
+<section>
+  <DeviceAdvanced
     {enableFields}
     on:settingsSaved={() => handleSettingsSaved()}
     on:settingsError={() => handleSettingsError()}

--- a/src/routes/[deviceUID]/DeviceAdvanced.svelte
+++ b/src/routes/[deviceUID]/DeviceAdvanced.svelte
@@ -63,7 +63,7 @@
   }
   .help-text {
     font-size: 0.9em;
-    color: #666;
+    color: var(--grey);
     margin-top: 0;
     margin-bottom: 1rem;
   }

--- a/src/routes/[deviceUID]/DeviceAdvanced.svelte
+++ b/src/routes/[deviceUID]/DeviceAdvanced.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  import { enhance } from '$app/forms';
+  import { routingUrl } from '$lib/stores/settingsStore';
+  import type { PotentiallyNullDeviceDetails } from '$lib/services/DeviceModel';
+
+  export let enableFields: boolean;
+  export let pin: PotentiallyNullDeviceDetails = '';
+
+  const dispatch = createEventDispatcher();
+
+  let formResponse: string;
+  $: if (formResponse === 'success') {
+    dispatch('settingsSaved');
+    formResponse = '';
+  } else if (formResponse === 'failure') {
+    dispatch('settingsError');
+    formResponse = '';
+  }
+</script>
+
+<h4 data-cy="device-advanced-title">Advanced</h4>
+
+<form
+  method="POST"
+  use:enhance={() => {
+    return async ({ result }) => {
+      formResponse = result.type;
+    };
+  }}
+  action="?&pin={pin}&/saveSettings"
+>
+  <div>
+    <label for="routingUrl">Routing URL</label>
+    <input
+      disabled={!enableFields}
+      type="url"
+      name="routingUrl"
+      bind:value={$routingUrl}
+      id="routingUrl"
+      placeholder="https://your-server.com/webhook"
+    />
+    <p class="help-text">
+      When set, Notehub forwards all incoming data from your Airnote to the
+      specified URL as a POST request, with the data included in the request
+      body.
+    </p>
+  </div>
+
+  {#if enableFields}
+    <div class="form-buttons">
+      <button>Update Advanced Settings</button>
+    </div>
+  {/if}
+</form>
+
+<style>
+  h4 {
+    text-align: center;
+  }
+  .form-buttons {
+    text-align: center;
+  }
+  .help-text {
+    font-size: 0.9em;
+    color: #666;
+    margin-top: 0;
+    margin-bottom: 1rem;
+  }
+</style>


### PR DESCRIPTION
# Problem Context

We’ve had a feature in the system for a long time where you can set a `_route` environment variable on your Airnote, and have Notehub automatically forward that information to a user’s own server. A [user had an issue retrieving their data on our forum](https://discuss.blues.com/t/retrieving-airnote-data-from-notehub/3280), and Ray asked for us to expose the `_route` variable through the UI.

## Changes

There’s a new textbox that I put in an “Advanced” section, as I figure very few people will actually need / want this. The new section follows the patterns of previous sections.

While I was in here I noticed a small bug: you can’t currently erase any of the text input form fields in production—aka if you empty them out, save, and refresh, the values are still there. I made a small tweak to update that in this PR too.

## Screenshot (if applicable)

<img width="1017" height="251" alt="Screenshot 2025-09-10 at 2 18 14 PM" src="https://github.com/user-attachments/assets/16f391b3-c73d-4083-a18d-190e4127aff5" />

## Testing

Set the new field and ensure `_route` gets set correctly in Notehub. Empty the new field and ensure `_route` is removed.
