### PR TITLE
fix: small spacing adjustments for measurements

### DIFF
--- a/src/routes/[deviceUID]/dashboard/+page.svelte
+++ b/src/routes/[deviceUID]/dashboard/+page.svelte
@@ -597,17 +597,24 @@
   }
   .measurement-pm,
   .measurement-air {
-    display: flex;
     text-align: center;
-    padding: 3rem 0;
+    padding: 2rem 1rem;
   }
-
+  .measurement-pm {
+    display: flex;
+  }
+  .measurement-air {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-rows: repeat(2, auto);
+  }
   .measurement-air {
     border-top: 1px solid var(--lightestGrey);
   }
   .measurement-pm > div,
   .measurement-air > div {
     flex-grow: 1;
+    margin: 0.5rem;
   }
   .measurement-air strong,
   .measurement-pm strong {
@@ -639,11 +646,11 @@
       left: 15%;
       width: 70%;
     }
+  }
 
-    @media (max-width: 376px) {
-      .box {
-        padding: 1.5rem 0.5rem;
-      }
+  @media (max-width: 376px) {
+    .box {
+      padding: 1.5rem 0.5rem;
     }
   }
 </style>


### PR DESCRIPTION
Tweaking the spacing a little based off a small Slack conversation. Mostly just made the environmental readings a 2x2 grid because they fit a little better this way. It only looked off at certain specific screen sizes, but I still think this is a change worth making.

Before:

<img width="990" height="1185" alt="Screenshot 2025-09-30 at 8 45 36 AM" src="https://github.com/user-attachments/assets/31ffcb2f-8703-4b5c-97d9-0080b929576c" />

After:

<img width="990" height="1185" alt="Screenshot 2025-09-30 at 8 45 39 AM" src="https://github.com/user-attachments/assets/c4bc7b97-21f2-4100-b142-9c6d65fb5d6a" />
