### PR TITLE
bug: fix time range to properly display prev 24 hours' of data [BLUESDEV-499]

### DIFF
--- a/src/lib/components/charts/AQIChart.svelte
+++ b/src/lib/components/charts/AQIChart.svelte
@@ -11,6 +11,8 @@
   import type { ChartDataPointType } from '$lib/services/ChartModel';
 
   export let readings: AirnoteReading[] = [];
+  export let min: number | undefined = undefined;
+  export let max: number | undefined = undefined;
 
   let aqiChart: Chart<'line', ChartDataPointType[], unknown>;
   let ctx: HTMLCanvasElement;
@@ -35,6 +37,11 @@
     aqiChart.update();
   }
 
+  $: if (aqiChart && (min !== undefined || max !== undefined)) {
+    aqiChart.options = options as any;
+    aqiChart.update();
+  }
+
   const data = {
     datasets: [
       {
@@ -49,7 +56,7 @@
     ]
   };
 
-  const options: ChartOptions<'line'> = {
+  $: options = ({
     maintainAspectRatio: false,
     scales: {
       x: {
@@ -62,7 +69,9 @@
         },
         ticks: {
           maxTicksLimit: 10
-        }
+        },
+        ...(min !== undefined && { min }),
+        ...(max !== undefined && { max })
       }
     },
     responsive: true,
@@ -79,7 +88,7 @@
         }
       }
     }
-  };
+  }) as ChartOptions<'line'>;
 
   const config: ChartConfiguration<'line', ChartDataPointType[], unknown> = {
     type: 'line',

--- a/src/lib/components/charts/AQIChart.svelte
+++ b/src/lib/components/charts/AQIChart.svelte
@@ -34,10 +34,6 @@
 
   $: if (aqiChart) {
     aqiChart.data.datasets[0].data = aqiData;
-    aqiChart.update();
-  }
-
-  $: if (aqiChart && (min !== undefined || max !== undefined)) {
     aqiChart.options = options as any;
     aqiChart.update();
   }

--- a/src/lib/components/charts/HumidityChart.svelte
+++ b/src/lib/components/charts/HumidityChart.svelte
@@ -36,10 +36,6 @@
 
   $: if (humdityChart) {
     humdityChart.data.datasets[0].data = humidityData;
-    humdityChart.update();
-  }
-
-  $: if (humdityChart && (min !== undefined || max !== undefined)) {
     humdityChart.options = options as any;
     humdityChart.update();
   }

--- a/src/lib/components/charts/HumidityChart.svelte
+++ b/src/lib/components/charts/HumidityChart.svelte
@@ -11,6 +11,8 @@
   import type { ChartDataPointType } from '$lib/services/ChartModel';
 
   export let readings: AirnoteReading[] = [];
+  export let min: number | undefined = undefined;
+  export let max: number | undefined = undefined;
 
   let humdityChart: Chart<'line', ChartDataPointType[], unknown>;
   let ctx: HTMLCanvasElement;
@@ -37,6 +39,11 @@
     humdityChart.update();
   }
 
+  $: if (humdityChart && (min !== undefined || max !== undefined)) {
+    humdityChart.options = options as any;
+    humdityChart.update();
+  }
+
   const data = {
     datasets: [
       {
@@ -51,7 +58,7 @@
     ]
   };
 
-  const options: ChartOptions<'line'> = {
+  $: options = ({
     maintainAspectRatio: false,
     scales: {
       x: {
@@ -64,7 +71,9 @@
         },
         ticks: {
           maxTicksLimit: 10
-        }
+        },
+        ...(min !== undefined && { min }),
+        ...(max !== undefined && { max })
       }
     },
     responsive: true,
@@ -81,7 +90,7 @@
         }
       }
     }
-  };
+  }) as ChartOptions<'line'>;
 
   const config: ChartConfiguration<'line', ChartDataPointType[], unknown> = {
     type: 'line',

--- a/src/lib/components/charts/PMChart.svelte
+++ b/src/lib/components/charts/PMChart.svelte
@@ -12,6 +12,8 @@
   import type { ChartDataPointType } from '$lib/services/ChartModel';
 
   export let readings: AirnoteReading[] = [];
+  export let min: number | undefined = undefined;
+  export let max: number | undefined = undefined;
 
   let pmChart: Chart<'line', ChartDataPointType[], unknown>;
   let ctx: HTMLCanvasElement;
@@ -60,6 +62,11 @@
     pmChart.update();
   }
 
+  $: if (pmChart && (min !== undefined || max !== undefined)) {
+    pmChart.options = options as any;
+    pmChart.update();
+  }
+
   const data: ChartData<'line', ChartDataPointType[], unknown> = {
     datasets: [
       {
@@ -89,7 +96,7 @@
     ]
   };
 
-  const options: ChartOptions<'line'> = {
+  $: options = ({
     maintainAspectRatio: false,
     scales: {
       x: {
@@ -102,7 +109,9 @@
         },
         ticks: {
           maxTicksLimit: 10
-        }
+        },
+        ...(min !== undefined && { min }),
+        ...(max !== undefined && { max })
       }
     },
     responsive: true,
@@ -119,7 +128,7 @@
         }
       }
     }
-  };
+  }) as ChartOptions<'line'>;
 
   const config: ChartConfiguration<'line', ChartDataPointType[], unknown> = {
     type: 'line',

--- a/src/lib/components/charts/PMChart.svelte
+++ b/src/lib/components/charts/PMChart.svelte
@@ -59,10 +59,6 @@
     pmChart.data.datasets[0].data = pm1Data;
     pmChart.data.datasets[1].data = pm2_5Data;
     pmChart.data.datasets[2].data = pm10Data;
-    pmChart.update();
-  }
-
-  $: if (pmChart && (min !== undefined || max !== undefined)) {
     pmChart.options = options as any;
     pmChart.update();
   }

--- a/src/lib/components/charts/TempChart.svelte
+++ b/src/lib/components/charts/TempChart.svelte
@@ -13,6 +13,8 @@
 
   export let readings: AirnoteReading[] = [];
   export let tempDisplay: string = 'C';
+  export let min: number | undefined = undefined;
+  export let max: number | undefined = undefined;
 
   let temperatureChart: Chart<'line' | 'bar', ChartDataPointType[], unknown>;
   let ctx: HTMLCanvasElement;
@@ -70,6 +72,11 @@
     temperatureChart.update();
   }
 
+  $: if (temperatureChart && (min !== undefined || max !== undefined)) {
+    temperatureChart.options = options as any;
+    temperatureChart.update();
+  }
+
   const data = {
     datasets: [
       {
@@ -93,7 +100,7 @@
     ]
   };
 
-  const options: ChartOptions<'line'> = {
+  $: options = ({
     maintainAspectRatio: false,
     scales: {
       x: {
@@ -106,7 +113,9 @@
         },
         ticks: {
           maxTicksLimit: 10
-        }
+        },
+        ...(min !== undefined && { min }),
+        ...(max !== undefined && { max })
       }
     },
     responsive: true,
@@ -123,7 +132,7 @@
         }
       }
     }
-  };
+  }) as ChartOptions<'line'>;
 
   const config: ChartConfiguration<'line', ChartDataPointType[], unknown> = {
     type: 'line',

--- a/src/lib/components/charts/TempChart.svelte
+++ b/src/lib/components/charts/TempChart.svelte
@@ -69,10 +69,6 @@
       temperatureChart.data.datasets[0].data = [];
       temperatureChart.data.datasets[1].data = tempDataFahrenheit;
     }
-    temperatureChart.update();
-  }
-
-  $: if (temperatureChart && (min !== undefined || max !== undefined)) {
     temperatureChart.options = options as any;
     temperatureChart.update();
   }

--- a/src/lib/components/charts/VoltageChart.svelte
+++ b/src/lib/components/charts/VoltageChart.svelte
@@ -12,6 +12,8 @@
   import type { ChartDataPointType } from '$lib/services/ChartModel';
 
   export let readings: AirnoteReading[] = [];
+  export let min: number | undefined = undefined;
+  export let max: number | undefined = undefined;
 
   let voltageChart: Chart<'line' | 'bar', ChartDataPointType[], unknown>;
   let ctx: HTMLCanvasElement;
@@ -54,6 +56,11 @@
     voltageChart.update();
   }
 
+  $: if (voltageChart && (min !== undefined || max !== undefined)) {
+    voltageChart.options = options as any;
+    voltageChart.update();
+  }
+
   const data: ChartData<'line' | 'bar', ChartDataPointType[], unknown> = {
     datasets: [
       {
@@ -76,7 +83,7 @@
     ]
   };
 
-  const options: ChartOptions<'line'> = {
+  $: options = ({
     maintainAspectRatio: false,
     scales: {
       x: {
@@ -89,7 +96,9 @@
         },
         ticks: {
           maxTicksLimit: 10
-        }
+        },
+        ...(min !== undefined && { min }),
+        ...(max !== undefined && { max })
       },
       y: {
         min: 2.5,
@@ -120,7 +129,7 @@
         }
       }
     }
-  };
+  }) as ChartOptions<'line'>;
 
   const config: ChartConfiguration<
     'line' | 'bar',

--- a/src/lib/components/charts/VoltageChart.svelte
+++ b/src/lib/components/charts/VoltageChart.svelte
@@ -53,10 +53,6 @@
   $: if (voltageChart) {
     voltageChart.data.datasets[0].data = voltageData;
     voltageChart.data.datasets[1].data = chargingData;
-    voltageChart.update();
-  }
-
-  $: if (voltageChart && (min !== undefined || max !== undefined)) {
     voltageChart.options = options as any;
     voltageChart.update();
   }

--- a/src/lib/util/dates.ts
+++ b/src/lib/util/dates.ts
@@ -34,6 +34,15 @@ export function filterEventsByDate(
   return events.filter((event) => isAfter(event.captured * 1000, startingDate));
 }
 
+export function getChartTimeRange(daysPrior: number) {
+  const now = new Date();
+  const startDate = subDays(now, daysPrior);
+  return {
+    min: startDate.getTime(),
+    max: now.getTime()
+  };
+}
+
 function convertToSeconds(millisecondsTimestamp: number) {
   return Math.floor(millisecondsTimestamp / 1000);
 }

--- a/src/routes/[deviceUID]/dashboard/+page.svelte
+++ b/src/routes/[deviceUID]/dashboard/+page.svelte
@@ -21,9 +21,9 @@
   import {
     convertDateRange,
     dateRangeDisplayText,
-    filterEventsByDate
+    filterEventsByDate,
+    getChartTimeRange
   } from '$lib/util/dates';
-  import { subDays } from 'date-fns/subDays';
   import { renderErrorMessage } from '$lib/util/errors';
 
   import Actions from './Actions.svelte';
@@ -91,10 +91,9 @@
     displayedReadings = filterEventsByDate(readings, convertedTimeframe);
 
     // Calculate time range for chart x-axis
-    const now = new Date();
-    const startDate = subDays(now, convertedTimeframe);
-    timeRangeMin = startDate.getTime();
-    timeRangeMax = now.getTime();
+    const timeRange = getChartTimeRange(convertedTimeframe);
+    timeRangeMin = timeRange.min;
+    timeRangeMax = timeRange.max;
 
     // if the selected date range is 30 days, expand the smaller charts to full width
     if (selectedDateRange === DATE_RANGE_OPTIONS.THIRTY_DAYS.displayText) {

--- a/src/routes/[deviceUID]/dashboard/+page.svelte
+++ b/src/routes/[deviceUID]/dashboard/+page.svelte
@@ -23,6 +23,7 @@
     dateRangeDisplayText,
     filterEventsByDate
   } from '$lib/util/dates';
+  import { subDays } from 'date-fns/subDays';
   import { renderErrorMessage } from '$lib/util/errors';
 
   import Actions from './Actions.svelte';
@@ -43,6 +44,8 @@
     pm10_0: {}
   };
   let displayedReadings: AirnoteReading[];
+  let timeRangeMin: number;
+  let timeRangeMax: number;
 
   let error = false;
   let errorType: string;
@@ -86,6 +89,13 @@
   $: if (selectedDateRange) {
     const convertedTimeframe = convertDateRange(selectedDateRange);
     displayedReadings = filterEventsByDate(readings, convertedTimeframe);
+
+    // Calculate time range for chart x-axis
+    const now = new Date();
+    const startDate = subDays(now, convertedTimeframe);
+    timeRangeMin = startDate.getTime();
+    timeRangeMax = now.getTime();
+
     // if the selected date range is 30 days, expand the smaller charts to full width
     if (selectedDateRange === DATE_RANGE_OPTIONS.THIRTY_DAYS.displayText) {
       expandCharts = true;
@@ -307,27 +317,29 @@
 
     <div class={chartLayout}>
       <div class="box chart1 {chartWidth}">
-        <VoltageChart readings={displayedReadings} />
+        <VoltageChart readings={displayedReadings} min={timeRangeMin} max={timeRangeMax} />
       </div>
 
       <div class="box chart2 {chartWidth}">
         <TempChart
           {tempDisplay}
           readings={displayedReadings}
+          min={timeRangeMin}
+          max={timeRangeMax}
           on:change={handleTempDisplayChange}
         />
       </div>
 
       <div class="box chart3 {chartWidth}">
-        <AQIChart readings={displayedReadings} />
+        <AQIChart readings={displayedReadings} min={timeRangeMin} max={timeRangeMax} />
       </div>
 
       <div class="box chart4 {chartWidth}">
-        <HumidityChart readings={displayedReadings} />
+        <HumidityChart readings={displayedReadings} min={timeRangeMin} max={timeRangeMax} />
       </div>
 
       <div class="box chart5">
-        <PMChart readings={displayedReadings} />
+        <PMChart readings={displayedReadings} min={timeRangeMin} max={timeRangeMax} />
       </div>
     </div>
     {#if showBanner}


### PR DESCRIPTION
# Problem Context

A user observed the following bug when viewing "Last Day" data in the charts: "In looking at 1 day right now, it is not actually 1 day.  It is about 5 hours shy of 1 day worth of data, which makes me wonder if there is some time zone thing going on given the fact that I'm in ET....Right now they are beginning at 15:00 of a certain day, and they are ending at the last data point which is 11:01" (context: this was reported 3 hours after the last data point was recorded)

## Changes

* Added time range calculation in `+page.svelte` file so when selected date range changes, it calculates `timeRangeMin` and `timeRangeMax` based on current local time minus selected number of days
* Pass `min` and `max` values to all charts for time range for x-axis to display and reactively update chart when time range changes

## Screenshot (if applicable)

Airnote.live site (notice the values go from 17:33 ET the day before to 11:01 ET today)
<img width="862" height="1265" alt="Screenshot 2025-10-31 at 4 47 49 PM" src="https://github.com/user-attachments/assets/83306973-f377-4ec4-ac77-a6888c122667" />

Local site (notice the values go from 16:48 ET the day before to 16:48 ET today even though there's been no new data since 11:01 ET)
<img width="872" height="1266" alt="Screenshot 2025-10-31 at 4 48 11 PM" src="https://github.com/user-attachments/assets/099abaef-c64a-42b5-bb47-92a8a5c1f3af" />

## Testing

Unit / integration / e2e tests?

All tests pass 

Steps to test manually?

1. Go to a device dashboard like: http://localhost:5173/dev:868531060198400/dashboard
2. See that when you view the charts, they all show a gap after the last recorded data point in them to show exactly 24 hours, 1 week, 14 days, etc. from the current time the user lands on the dashboard instead of the last time the device checked in which can then make gaps in data much more visible

Any other sorts of testing notes to include?

## Any other related PRs

n/a

## Ticket(s)

https://bluesinc.atlassian.net/jira/software/c/projects/BLUESDEV/boards/13?selectedIssue=BLUESDEV-499
