### PR TITLE
bug: filter out undefined readings from Notehub that break the charts & dashboard [BLUESDEV-507]

### DIFF
--- a/src/lib/components/charts/AQIChart.svelte
+++ b/src/lib/components/charts/AQIChart.svelte
@@ -23,13 +23,15 @@
   }
 
   function getAQIData(readings: AirnoteReading[]) {
-    aqiData = readings.map((reading) => {
-      const d = reading.captured * 1000;
-      return {
-        x: d,
-        y: reading.aqi
-      };
-    });
+    aqiData = readings
+      .filter((reading) => reading.aqi !== undefined)
+      .map((reading) => {
+        const d = reading.captured * 1000;
+        return {
+          x: d,
+          y: reading.aqi
+        };
+      });
   }
 
   $: if (aqiChart) {

--- a/src/lib/components/charts/HumidityChart.svelte
+++ b/src/lib/components/charts/HumidityChart.svelte
@@ -23,15 +23,15 @@
   }
 
   function getHumidityData(readings: AirnoteReading[]) {
-    humidityData = readings.map((reading) => {
-      const d = reading.captured * 1000;
-      return {
-        x: d,
-        y: reading.humidity
-          ? parseFloat(reading.humidity.toString()).toFixed(2)
-          : 0.0
-      };
-    });
+    humidityData = readings
+      .filter((reading) => reading.humidity !== undefined)
+      .map((reading) => {
+        const d = reading.captured * 1000;
+        return {
+          x: d,
+          y: parseFloat(reading.humidity.toString()).toFixed(2)
+        };
+      });
   }
 
   $: if (humdityChart) {

--- a/src/lib/components/charts/PMChart.svelte
+++ b/src/lib/components/charts/PMChart.svelte
@@ -26,33 +26,35 @@
   }
 
   function getPMData(readings: AirnoteReading[]) {
-    pm1Data = readings.map((reading) => {
-      const d = reading.captured * 1000;
-      return {
-        x: d,
-        y: reading.pm01_0
-          ? parseFloat(reading.pm01_0.toString()).toFixed(2)
-          : 0.0
-      };
-    });
-    pm2_5Data = readings.map((reading) => {
-      const d = reading.captured * 1000;
-      return {
-        x: d,
-        y: reading.pm02_5
-          ? parseFloat(reading.pm02_5.toString()).toFixed(2)
-          : 0.0
-      };
-    });
-    pm10Data = readings.map((reading) => {
-      const d = reading.captured * 1000;
-      return {
-        x: d,
-        y: reading.pm10_0
-          ? parseFloat(reading.pm10_0.toString()).toFixed(2)
-          : 0.0
-      };
-    });
+    pm1Data = readings
+      .filter((reading) => reading.pm01_0 !== undefined)
+      .map((reading) => {
+        const d = reading.captured * 1000;
+        return {
+          x: d,
+          y: parseFloat(reading.pm01_0.toString()).toFixed(2)
+        };
+      });
+
+    pm2_5Data = readings
+      .filter((reading) => reading.pm02_5 !== undefined)
+      .map((reading) => {
+        const d = reading.captured * 1000;
+        return {
+          x: d,
+          y: parseFloat(reading.pm02_5.toString()).toFixed(2)
+        };
+      });
+
+    pm10Data = readings
+      .filter((reading) => reading.pm10_0 !== undefined)
+      .map((reading) => {
+        const d = reading.captured * 1000;
+        return {
+          x: d,
+          y: parseFloat(reading.pm10_0.toString()).toFixed(2)
+        };
+      });
   }
 
   $: if (pmChart) {

--- a/src/lib/components/charts/TempChart.svelte
+++ b/src/lib/components/charts/TempChart.svelte
@@ -28,22 +28,21 @@
   }
 
   function getTempData(readings: AirnoteReading[]) {
-    tempDataCelsius = readings.map((reading) => {
+    const validReadings = readings.filter((reading) => reading.temperature !== undefined);
+
+    tempDataCelsius = validReadings.map((reading) => {
       const d = reading.captured * 1000;
       return {
         x: d,
-        y: reading.temperature
-          ? parseFloat(reading.temperature.toString()).toFixed(2)
-          : 0.0
+        y: parseFloat(reading.temperature.toString()).toFixed(2)
       };
     });
-    tempDataFahrenheit = readings.map((reading) => {
+
+    tempDataFahrenheit = validReadings.map((reading) => {
       const d = reading.captured * 1000;
       return {
         x: d,
-        y: reading.temperature
-          ? parseFloat(toFahrenheit(reading.temperature).toString()).toFixed(2)
-          : 0.0
+        y: parseFloat(toFahrenheit(reading.temperature).toString()).toFixed(2)
       };
     });
   }

--- a/src/lib/components/charts/VoltageChart.svelte
+++ b/src/lib/components/charts/VoltageChart.svelte
@@ -29,17 +29,18 @@
   }
 
   function getVoltageData(readings: AirnoteReading[]) {
-    voltageData = readings.reverse().map((reading) => {
-      const d = reading.captured * 1000;
-      return {
-        x: d,
-        y: reading.voltage
-          ? parseFloat(reading.voltage.toString()).toFixed(2)
-          : 0.0
-      };
-    });
+    voltageData = readings
+      .reverse()
+      .filter((reading) => reading.voltage !== undefined)
+      .map((reading) => {
+        const d = reading.captured * 1000;
+        return {
+          x: d,
+          y: parseFloat(reading.voltage.toString()).toFixed(2)
+        };
+      });
     chargingData = readings
-      .filter((reading) => reading.charging)
+      .filter((reading) => reading.charging && reading.voltage)
       .map((reading) => {
         const d = reading.captured * 1000;
         return {
@@ -79,7 +80,7 @@
     ]
   };
 
-  $: options = ({
+  $: options = {
     maintainAspectRatio: false,
     scales: {
       x: {
@@ -125,7 +126,7 @@
         }
       }
     }
-  }) as ChartOptions<'line'>;
+  } as ChartOptions<'line'>;
 
   const config: ChartConfiguration<
     'line' | 'bar',


### PR DESCRIPTION
# Problem Context

A user reported they couldn't see their dashboard despite it sending plenty of events regularly. Upon closer inspection, some `charging: undefined` value had made its way to the Voltage chart and caused it to throw an error, which caused the whole page not render correctly.

## Changes

Update all the Airnote charts to filter out any `undefined` values before attempting to render the chart data to avoid such errors in the future.

## Screenshot (if applicable)

Prod version of Airnote
<img width="1097" height="455" alt="Screenshot 2025-12-12 at 5 36 53 PM" src="https://github.com/user-attachments/assets/b06a3811-8094-49fc-8484-1afc132cfc5e" />

Local version of Airnote
<img width="1552" height="976" alt="Screenshot 2025-12-12 at 5 36 43 PM" src="https://github.com/user-attachments/assets/f4780291-333c-4017-ae0e-2320d656c1f3" />

## Testing

Unit / integration / e2e tests?

All tests pass 

Steps to test manually?

1. Go to this Airnote dashboard in prod: https://airnote.live/dev:868531061607359/dashboard
2. Go to this Airnote dashboard in local dev: http://localhost:5173/dev:868531061607359/dashboard
3. See that the local dev dashboard renders correctly

Any other sorts of testing notes to include?

## Any other related PRs

n/a

## Ticket(s)

https://bluesinc.atlassian.net/jira/software/c/projects/BLUESDEV/boards/13?selectedIssue=BLUESDEV-507
