### PR TITLE
feat: Handle Airnote v3

### DIFF
--- a/cypress/e2e/airnote-product-versions.spec.cy.ts
+++ b/cypress/e2e/airnote-product-versions.spec.cy.ts
@@ -1,0 +1,114 @@
+describe('Airnote Product Version Configurations', () => {
+  describe('Legacy Airnote (non-v3)', () => {
+    it('should display legacy Airnote-specific display options on settings page', () => {
+      cy.setLocalStorage();
+      cy.visit('/');
+      cy.get('[data-cy="settings-link"]').click();
+
+      // Check that PM2.5 is a display option (legacy default)
+      cy.get('select[name="displayValue"]').should('exist');
+      cy.get('select[name="displayValue"] option[value="pm2.5"]').should(
+        'contain',
+        'PM2.5 (default)'
+      );
+
+      // Check that legacy PM options are present
+      cy.get('select[name="displayValue"] option[value="pm1.0"]').should(
+        'exist'
+      );
+      cy.get('select[name="displayValue"] option[value="pm10.0"]').should(
+        'exist'
+      );
+
+      // Verify v3-specific AQI default is NOT present
+      cy.get('select[name="displayValue"] option').should(
+        'not.contain',
+        'AQI (default)'
+      );
+
+      // Check that common options are present
+      cy.get('select[name="displayValue"] option[value="tempc"]').should(
+        'exist'
+      );
+      cy.get('select[name="displayValue"] option[value="tempf"]').should(
+        'exist'
+      );
+      cy.get('select[name="displayValue"] option[value="humid"]').should(
+        'exist'
+      );
+      cy.get('select[name="displayValue"] option[value="press"]').should(
+        'exist'
+      );
+    });
+
+    it('should have correct productUID in URL for legacy Airnote', () => {
+      cy.setLocalStorage();
+      cy.visit('/');
+      cy.get('[data-cy="settings-link"]').click();
+
+      // Check URL contains correct legacy product UID (either v1 variant)
+      cy.url().should('satisfy', (url: string) => {
+        return (
+          url.includes('product%3Aorg.airnote.solar.v1') ||
+          url.includes('product%3Aorg.airnote.solar.air.v1')
+        );
+      });
+    });
+  });
+
+  describe('Airnote V3', () => {
+    it('should display v3 Airnote-specific display options on settings page', () => {
+      // Use v3 device setup
+      cy.setLocalStorageV3();
+      cy.visit('/');
+      cy.get('[data-cy="settings-link"]').click();
+
+      // Check that AQI is the default option for v3
+      cy.get('select[name="displayValue"]').should('exist');
+      cy.get('select[name="displayValue"] option[value="aqi"]').should(
+        'contain',
+        'AQI (default)'
+      );
+
+      // Check that v3 PM options are present (but not as default)
+      cy.get('select[name="displayValue"] option[value="pm2.5"]').should(
+        'exist'
+      );
+      cy.get('select[name="displayValue"] option[value="pm1.0"]').should(
+        'exist'
+      );
+      cy.get('select[name="displayValue"] option[value="pm10.0"]').should(
+        'exist'
+      );
+
+      // Verify legacy PM2.5 default is NOT present
+      cy.get('select[name="displayValue"] option').should(
+        'not.contain',
+        'PM2.5 (default)'
+      );
+
+      // Check that common options are present
+      cy.get('select[name="displayValue"] option[value="tempc"]').should(
+        'exist'
+      );
+      cy.get('select[name="displayValue"] option[value="tempf"]').should(
+        'exist'
+      );
+      cy.get('select[name="displayValue"] option[value="humid"]').should(
+        'exist'
+      );
+      cy.get('select[name="displayValue"] option[value="press"]').should(
+        'exist'
+      );
+    });
+
+    it('should have correct productUID in URL for v3 Airnote', () => {
+      cy.setLocalStorageV3();
+      cy.visit('/');
+      cy.get('[data-cy="settings-link"]').click();
+
+      // Check URL contains correct v3 product UID (URL-encoded)
+      cy.url().should('include', 'product%3Acom.blues.airnote.v3');
+    });
+  });
+});

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -21,11 +21,13 @@ import './commands';
 import * as setupCommands from './setup/setup_commands';
 
 Cypress.Commands.add('setLocalStorage', setupCommands.setLocalStorage);
+Cypress.Commands.add('setLocalStorageV3', setupCommands.setLocalStorageV3);
 
 declare global {
   namespace Cypress {
     interface Chainable {
       setLocalStorage: typeof setupCommands.setLocalStorage;
+      setLocalStorageV3: typeof setupCommands.setLocalStorageV3;
     }
   }
 }

--- a/cypress/support/setup/setup_commands.ts
+++ b/cypress/support/setup/setup_commands.ts
@@ -10,3 +10,16 @@ export const setLocalStorage = () => {
     );
   });
 };
+
+export const setLocalStorageV3 = () => {
+  cy.window().then((win) => {
+    win.localStorage.setItem(
+      'device',
+      JSON.stringify({
+        deviceUID: 'dev:868531060199234',
+        pin: '1234',
+        productUID: 'product:com.blues.airnote.v3'
+      })
+    );
+  });
+};

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,5 @@
 export const AIRNOTE_PRODUCT_UID = 'product:org.airnote.solar.v1';
+export const AIRNOTE_V3_PRODUCT_UID = 'product:com.blues.airnote.v3';
 export const RADNOTE_PRODUCT_UID = 'product:org.airnote.solar.rad.v1';
 export const APP_UID = 'app:2606f411-dea6-44a0-9743-1130f57d77d8';
 

--- a/src/lib/services/DeviceEnvVarModel.ts
+++ b/src/lib/services/DeviceEnvVarModel.ts
@@ -1,8 +1,11 @@
 export interface DeviceEnvVars {
   _sn: string | FormDataEntryValue | null;
   _air_mins?: string | FormDataEntryValue | null;
-  _air_indoors: string | FormDataEntryValue | null;
-  _air_status: string | FormDataEntryValue | null;
+  air_mins?: string | FormDataEntryValue | null; // V3 Airnote env var
+  _air_indoors?: string | FormDataEntryValue | null;
+  air_indoors?: string | FormDataEntryValue | null; // V3 Airnote env var
+  _air_status?: string | FormDataEntryValue | null;
+  air_status?: string | FormDataEntryValue | null; // V3 Airnote env var
   _contact_name: string | FormDataEntryValue | null;
   _contact_email: string | FormDataEntryValue | null;
   _contact_affiliation: string | FormDataEntryValue | null;

--- a/src/lib/services/notehub.ts
+++ b/src/lib/services/notehub.ts
@@ -2,6 +2,7 @@ import * as NotehubJs from '@blues-inc/notehub-js';
 import { HUB_AUTH_TOKEN } from '$env/static/private';
 import { convertTimeframeToSeconds } from '$lib/util/dates';
 import type { DeviceEnvVars } from './DeviceEnvVarModel';
+import { AIRNOTE_V3_PRODUCT_UID } from '$lib/constants';
 
 const AIRNOTE_PROJECT_UID = 'app:2606f411-dea6-44a0-9743-1130f57d77d8';
 
@@ -14,7 +15,8 @@ export function isValidProductUID(productUID: string) {
   const validProductUIDPrefixes = [
     'com.blues.airnote',
     'product:org.airnote.solar.v1',
-    'product:org.airnote.solar.air.v1'
+    'product:org.airnote.solar.air.v1',
+    'product:com.blues.airnote.v3'
   ];
   return validProductUIDPrefixes.some((prefix) =>
     productUID.startsWith(prefix)
@@ -24,6 +26,20 @@ export function isValidProductUID(productUID: string) {
 const notehubJsClient = NotehubJs.ApiClient.instance;
 const deviceApiInstance = new NotehubJs.DeviceApi();
 const eventApiInstance = new NotehubJs.EventApi();
+
+// get device info including productUID
+export async function getDeviceInfo(deviceUID: string) {
+  if (!isValidDeviceUID(deviceUID)) {
+    console.warn(
+      `Invalid device UID ${deviceUID}. Skipping getDevice() API call.`
+    );
+    return null;
+  }
+
+  const { api_key } = notehubJsClient.authentications;
+  api_key.apiKey = HUB_AUTH_TOKEN;
+  return await deviceApiInstance.getDevice(AIRNOTE_PROJECT_UID, deviceUID);
+}
 
 // read env vars only
 export async function getDeviceEnvironmentVariables(deviceUID: string) {
@@ -76,8 +92,8 @@ async function deleteDeviceEnvironmentVariable(deviceUID: string, key: string) {
     );
   }
 
-  const { pin } = notehubJsClient.authentications;
-  pin.apiKey = HUB_AUTH_TOKEN;
+  const { api_key } = notehubJsClient.authentications;
+  api_key.apiKey = HUB_AUTH_TOKEN;
   return await deviceApiInstance.deleteDeviceEnvironmentVariable(
     AIRNOTE_PROJECT_UID,
     deviceUID,
@@ -122,6 +138,16 @@ export async function updateDeviceEnvironmentVariablesByPin(
   pinNumber: string,
   environmentVariables: DeviceEnvVars
 ) {
+  console.log(
+    'updateDeviceEnvironmentVariablesByPin - productUID:',
+    productUID
+  );
+  console.log('updateDeviceEnvironmentVariablesByPin - deviceUID:', deviceUID);
+  console.log(
+    'updateDeviceEnvironmentVariablesByPin - environmentVariables:',
+    JSON.stringify(environmentVariables, null, 2)
+  );
+
   if (!isValidDeviceUID(deviceUID)) {
     console.warn(
       `Invalid device UID ${deviceUID}. Skipping updateDeviceEnvVar() API call.`
@@ -134,16 +160,36 @@ export async function updateDeviceEnvironmentVariablesByPin(
     );
   }
 
-  // If the _air_mins environment variable is set to the default, don't save the value so
-  // the device defaults to the project-level _air_mins. Also, delete the environment variable
+  // If the air_mins environment variable is set to the default, don't save the value so
+  // the device defaults to the project-level air_mins. Also, delete the environment variable
   // on the device in case it already exists.
+  const isV3 = productUID === AIRNOTE_V3_PRODUCT_UID;
+  const airMinsKey = isV3 ? 'air_mins' : '_air_mins';
+
+  console.log(
+    'updateDeviceEnvironmentVariablesByPin - isV3:',
+    isV3,
+    'airMinsKey:',
+    airMinsKey
+  );
+
+  // todo fix linting error and possibly refactor
   if (
-    environmentVariables._air_mins &&
-    environmentVariables._air_mins.toString().includes('high:30')
+    environmentVariables[airMinsKey] &&
+    environmentVariables[airMinsKey].toString().includes('high:30')
   ) {
-    delete environmentVariables._air_mins;
-    await deleteDeviceEnvironmentVariable(deviceUID, '_air_mins');
+    console.log(
+      'updateDeviceEnvironmentVariablesByPin - Deleting default air_mins'
+    );
+    delete environmentVariables[airMinsKey];
+    await deleteDeviceEnvironmentVariable(deviceUID, airMinsKey);
   }
+
+  console.log(
+    'updateDeviceEnvironmentVariablesByPin - Final payload:',
+    JSON.stringify(environmentVariables, null, 2)
+  );
+
   return await putDeviceEnvironmentVariablesByPin(
     productUID,
     deviceUID,

--- a/src/lib/services/notehub.ts
+++ b/src/lib/services/notehub.ts
@@ -138,16 +138,6 @@ export async function updateDeviceEnvironmentVariablesByPin(
   pinNumber: string,
   environmentVariables: DeviceEnvVars
 ) {
-  console.log(
-    'updateDeviceEnvironmentVariablesByPin - productUID:',
-    productUID
-  );
-  console.log('updateDeviceEnvironmentVariablesByPin - deviceUID:', deviceUID);
-  console.log(
-    'updateDeviceEnvironmentVariablesByPin - environmentVariables:',
-    JSON.stringify(environmentVariables, null, 2)
-  );
-
   if (!isValidDeviceUID(deviceUID)) {
     console.warn(
       `Invalid device UID ${deviceUID}. Skipping updateDeviceEnvVar() API call.`
@@ -166,29 +156,13 @@ export async function updateDeviceEnvironmentVariablesByPin(
   const isV3 = productUID === AIRNOTE_V3_PRODUCT_UID;
   const airMinsKey = isV3 ? 'air_mins' : '_air_mins';
 
-  console.log(
-    'updateDeviceEnvironmentVariablesByPin - isV3:',
-    isV3,
-    'airMinsKey:',
-    airMinsKey
-  );
-
-  // todo fix linting error and possibly refactor
   if (
     environmentVariables[airMinsKey] &&
     environmentVariables[airMinsKey].toString().includes('high:30')
   ) {
-    console.log(
-      'updateDeviceEnvironmentVariablesByPin - Deleting default air_mins'
-    );
     delete environmentVariables[airMinsKey];
     await deleteDeviceEnvironmentVariable(deviceUID, airMinsKey);
   }
-
-  console.log(
-    'updateDeviceEnvironmentVariablesByPin - Final payload:',
-    JSON.stringify(environmentVariables, null, 2)
-  );
 
   return await putDeviceEnvironmentVariablesByPin(
     productUID,

--- a/src/routes/[deviceUID]/+page.server.ts
+++ b/src/routes/[deviceUID]/+page.server.ts
@@ -12,14 +12,13 @@ import { AIRNOTE_PRODUCT_UID, AIRNOTE_V3_PRODUCT_UID } from '$lib/constants.js';
 
 export async function load({ params, url }) {
   const deviceUID = params.deviceUID;
-  let productUID = url.searchParams.get('product') || AIRNOTE_PRODUCT_UID;
   const pin = url.searchParams.get('pin');
   const internalNav = url.searchParams.get('internalNav');
 
   if (!isValidDeviceUID(deviceUID)) {
     return {
       notehubResponse: null,
-      productUID,
+      productUID: url.searchParams.get('product') || AIRNOTE_PRODUCT_UID,
       error: { errorType: ERROR_TYPE.NOTEHUB_ERROR }
     };
   }
@@ -35,14 +34,22 @@ export async function load({ params, url }) {
   let error;
   let notehubResponse;
 
-  // Fetch device info to get the real productUID
+  // Fetch device info to get the real productUID - this is critical
   const deviceInfo = await getDeviceInfo(deviceUID).catch((err) => {
     console.error('Error fetching device info:', err);
+    notehubError = err;
   });
 
-  if (deviceInfo && deviceInfo.product_uid) {
-    productUID = deviceInfo.product_uid;
+  if (!deviceInfo || !deviceInfo.product_uid) {
+    // Can't proceed without knowing the correct productUID (v3 vs legacy affects env var format)
+    return {
+      notehubResponse: null,
+      productUID: url.searchParams.get('product') || AIRNOTE_PRODUCT_UID,
+      error: { errorType: ERROR_TYPE.NOTEHUB_ERROR }
+    };
   }
+
+  const productUID = deviceInfo.product_uid;
 
   const envVarResponse = await getDeviceEnvironmentVariables(deviceUID).catch(
     (err) => {
@@ -66,7 +73,7 @@ export async function load({ params, url }) {
     );
   }
 
-  if (notehubError) {
+  if (notehubError && !error) {
     error = { errorType: ERROR_TYPE.NOTEHUB_ERROR };
   }
 
@@ -76,7 +83,6 @@ export async function load({ params, url }) {
 export const actions = {
   saveSettings: async ({ params, url, request }) => {
     const deviceUID = params.deviceUID;
-    let productUID = url.searchParams.get('product') || AIRNOTE_PRODUCT_UID;
     const pin = url.searchParams.get('pin');
     const body = await request.formData();
 
@@ -87,14 +93,19 @@ export const actions = {
     let notehubError: { status: number } | undefined;
     let error;
 
-    // Fetch device info to get the real productUID
+    // Fetch device info to get the real productUID - critical for env var format
     const deviceInfo = await getDeviceInfo(deviceUID).catch((err) => {
       console.error('Error fetching device info:', err);
+      notehubError = err;
     });
 
-    if (deviceInfo && deviceInfo.product_uid) {
-      productUID = deviceInfo.product_uid;
+    if (!deviceInfo || !deviceInfo.product_uid) {
+      return fail(500, {
+        error: { errorType: ERROR_TYPE.NOTEHUB_ERROR }
+      });
     }
+
+    const productUID = deviceInfo.product_uid;
 
     let currentEnvVars;
     try {
@@ -107,16 +118,11 @@ export const actions = {
       notehubError = err as { status: number };
     }
 
-    // todo fix linting error
+    const isV3 = productUID === AIRNOTE_V3_PRODUCT_UID;
     const formattedBody: DeviceEnvVars = createEnvVarBody(
       body,
       currentEnvVars,
-      productUID
-    );
-
-    console.log(
-      'saveSettings - formattedBody to be sent:',
-      JSON.stringify(formattedBody, null, 2)
+      isV3
     );
 
     if (pin === '') {
@@ -151,10 +157,9 @@ export const actions = {
 function determineCurrentCheckboxState(
   formData: FormData,
   envVars: { [x: string]: string },
-  productUID: string
+  isV3: boolean
 ) {
   let currentCheckboxState: string;
-  const isV3 = productUID === AIRNOTE_V3_PRODUCT_UID;
 
   // required logic because unchecked checkboxes are not included in the form data
   // figure out if device settings form is being submitted
@@ -178,82 +183,55 @@ function determineCurrentCheckboxState(
 function formatAirSamplingInterval(
   formData: FormData,
   envVars: { [x: string]: string },
-  productUID: string
+  isV3: boolean
 ) {
-  const isV3 = productUID === AIRNOTE_V3_PRODUCT_UID;
-  const airMinsKey = isV3 ? 'air_mins' : '_air_mins';
+  const sampleFrequency = formData.get('sampleFrequencyFull');
 
-  if (formData.get('sampleFrequencyFull')) {
-    return `usb:15;high:${formData.get(
-      'sampleFrequencyFull'
-    )};normal:${formData.get('sampleFrequencyFull')};low:720;43200`;
-  } else {
-    return envVars[airMinsKey];
+  if (sampleFrequency) {
+    return `usb:15;high:${sampleFrequency};normal:${sampleFrequency};low:720;43200`;
   }
+
+  const airMinsKey = isV3 ? 'air_mins' : '_air_mins';
+  return envVars[airMinsKey];
 }
 
 function createEnvVarBody(
   formData: FormData,
   envVars: { [x: string]: string },
-  productUID: string
+  isV3: boolean
 ) {
   // combine existing Airnote env vars with the new form data for accurate env var bdy request
-  const isV3 = productUID === AIRNOTE_V3_PRODUCT_UID;
   const currentCheckboxState = determineCurrentCheckboxState(
     formData,
     envVars,
-    productUID
+    isV3
   );
 
-  console.log('createEnvVarBody - Is v3:', isV3, 'productUID:', productUID);
-
   // For v3 devices, use env vars without underscores. For legacy devices, use with underscores.
-  // todo refactor to reduce redundancy
-  if (isV3) {
-    return {
-      _sn: formData.has('deviceName')
-        ? formData.get('deviceName')
-        : envVars['_sn'],
-      air_mins: formatAirSamplingInterval(formData, envVars, productUID),
-      air_indoors: currentCheckboxState,
-      air_status: formData.get('displayValue')
-        ? formData.get('displayValue')
-        : envVars['air_status'],
-      _contact_name: formData.has('contactName')
-        ? formData.get('contactName')
-        : envVars['_contact_name'],
-      _contact_email: formData.has('contactEmail')
-        ? formData.get('contactEmail')
-        : envVars['_contact_email'],
-      _contact_affiliation: formData.has('contactAffiliation')
-        ? formData.get('contactAffiliation')
-        : envVars['_contact_affiliation'],
-      _route: formData.has('routingUrl')
-        ? formData.get('routingUrl')
-        : envVars['_route']
-    };
-  } else {
-    return {
-      _sn: formData.has('deviceName')
-        ? formData.get('deviceName')
-        : envVars['_sn'],
-      _air_mins: formatAirSamplingInterval(formData, envVars, productUID),
-      _air_indoors: currentCheckboxState,
-      _air_status: formData.get('displayValue')
-        ? formData.get('displayValue')
-        : envVars['_air_status'],
-      _contact_name: formData.has('contactName')
-        ? formData.get('contactName')
-        : envVars['_contact_name'],
-      _contact_email: formData.has('contactEmail')
-        ? formData.get('contactEmail')
-        : envVars['_contact_email'],
-      _contact_affiliation: formData.has('contactAffiliation')
-        ? formData.get('contactAffiliation')
-        : envVars['_contact_affiliation'],
-      _route: formData.has('routingUrl')
-        ? formData.get('routingUrl')
-        : envVars['_route']
-    };
-  }
+  const airMinsKey = isV3 ? 'air_mins' : '_air_mins';
+  const airIndoorsKey = isV3 ? 'air_indoors' : '_air_indoors';
+  const airStatusKey = isV3 ? 'air_status' : '_air_status';
+
+  return {
+    _sn: formData.has('deviceName')
+      ? formData.get('deviceName')
+      : envVars['_sn'],
+    [airMinsKey]: formatAirSamplingInterval(formData, envVars, isV3),
+    [airIndoorsKey]: currentCheckboxState,
+    [airStatusKey]: formData.get('displayValue')
+      ? formData.get('displayValue')
+      : envVars[airStatusKey],
+    _contact_name: formData.has('contactName')
+      ? formData.get('contactName')
+      : envVars['_contact_name'],
+    _contact_email: formData.has('contactEmail')
+      ? formData.get('contactEmail')
+      : envVars['_contact_email'],
+    _contact_affiliation: formData.has('contactAffiliation')
+      ? formData.get('contactAffiliation')
+      : envVars['_contact_affiliation'],
+    _route: formData.has('routingUrl')
+      ? formData.get('routingUrl')
+      : envVars['_route']
+  };
 }

--- a/src/routes/[deviceUID]/+page.server.ts
+++ b/src/routes/[deviceUID]/+page.server.ts
@@ -1,5 +1,6 @@
 import { fail, redirect } from '@sveltejs/kit';
 import {
+  getDeviceInfo,
   getDeviceEnvironmentVariables,
   getDeviceEnvironmentVariablesByPin,
   updateDeviceEnvironmentVariablesByPin,
@@ -7,23 +8,24 @@ import {
 } from '$lib/services/notehub';
 import { ERROR_TYPE } from '$lib/constants/ErrorTypes.js';
 import type { DeviceEnvVars } from '$lib/services/DeviceEnvVarModel.js';
-import { AIRNOTE_PRODUCT_UID } from '$lib/constants.js';
+import { AIRNOTE_PRODUCT_UID, AIRNOTE_V3_PRODUCT_UID } from '$lib/constants.js';
 
 export async function load({ params, url }) {
   const deviceUID = params.deviceUID;
-  const productUID = url.searchParams.get('product') || AIRNOTE_PRODUCT_UID;
+  let productUID = url.searchParams.get('product') || AIRNOTE_PRODUCT_UID;
   const pin = url.searchParams.get('pin');
   const internalNav = url.searchParams.get('internalNav');
 
   if (!isValidDeviceUID(deviceUID)) {
     return {
       notehubResponse: null,
+      productUID,
       error: { errorType: ERROR_TYPE.NOTEHUB_ERROR }
     };
   }
 
-  /* Notehub links to a device’s dashboard using `/${deviceUID}` with no pin,
-    and we want Notehub users to view the device’s dashboard, and not the
+  /* Notehub links to a device's dashboard using `/${deviceUID}` with no pin,
+    and we want Notehub users to view the device's dashboard, and not the
     settings page when first directed there from Notehub. */
   if (deviceUID && !pin && internalNav === null) {
     redirect(302, `/${deviceUID}/dashboard`);
@@ -32,6 +34,15 @@ export async function load({ params, url }) {
   let notehubError: { status: number } | undefined;
   let error;
   let notehubResponse;
+
+  // Fetch device info to get the real productUID
+  const deviceInfo = await getDeviceInfo(deviceUID).catch((err) => {
+    console.error('Error fetching device info:', err);
+  });
+
+  if (deviceInfo && deviceInfo.product_uid) {
+    productUID = deviceInfo.product_uid;
+  }
 
   const envVarResponse = await getDeviceEnvironmentVariables(deviceUID).catch(
     (err) => {
@@ -59,13 +70,13 @@ export async function load({ params, url }) {
     error = { errorType: ERROR_TYPE.NOTEHUB_ERROR };
   }
 
-  return { notehubResponse, error };
+  return { notehubResponse, productUID, error };
 }
 
 export const actions = {
   saveSettings: async ({ params, url, request }) => {
     const deviceUID = params.deviceUID;
-    const productUID = url.searchParams.get('product') || AIRNOTE_PRODUCT_UID;
+    let productUID = url.searchParams.get('product') || AIRNOTE_PRODUCT_UID;
     const pin = url.searchParams.get('pin');
     const body = await request.formData();
 
@@ -75,6 +86,15 @@ export const actions = {
 
     let notehubError: { status: number } | undefined;
     let error;
+
+    // Fetch device info to get the real productUID
+    const deviceInfo = await getDeviceInfo(deviceUID).catch((err) => {
+      console.error('Error fetching device info:', err);
+    });
+
+    if (deviceInfo && deviceInfo.product_uid) {
+      productUID = deviceInfo.product_uid;
+    }
 
     let currentEnvVars;
     try {
@@ -87,7 +107,17 @@ export const actions = {
       notehubError = err as { status: number };
     }
 
-    const formattedBody: DeviceEnvVars = createEnvVarBody(body, currentEnvVars);
+    // todo fix linting error
+    const formattedBody: DeviceEnvVars = createEnvVarBody(
+      body,
+      currentEnvVars,
+      productUID
+    );
+
+    console.log(
+      'saveSettings - formattedBody to be sent:',
+      JSON.stringify(formattedBody, null, 2)
+    );
 
     if (pin === '') {
       error = { errorType: ERROR_TYPE.MISSING_PIN };
@@ -100,7 +130,11 @@ export const actions = {
           formattedBody
         );
       } catch (err) {
-        console.error(err);
+        console.error('saveSettings - Error updating device env vars:', err);
+        console.error(
+          'saveSettings - Error details:',
+          JSON.stringify(err, null, 2)
+        );
         notehubError = err as { status: number };
       }
 
@@ -116,9 +150,12 @@ export const actions = {
 
 function determineCurrentCheckboxState(
   formData: FormData,
-  envVars: { [x: string]: string }
+  envVars: { [x: string]: string },
+  productUID: string
 ) {
   let currentCheckboxState: string;
+  const isV3 = productUID === AIRNOTE_V3_PRODUCT_UID;
+
   // required logic because unchecked checkboxes are not included in the form data
   // figure out if device settings form is being submitted
   if (formData.get('deviceName')) {
@@ -130,8 +167,9 @@ function determineCurrentCheckboxState(
     }
   } else {
     // if device owner settings are submitted, get current checkbox state from envVars
-    currentCheckboxState = envVars['_air_indoors']
-      ? envVars['_air_indoors']
+    const airIndoorsKey = isV3 ? 'air_indoors' : '_air_indoors';
+    currentCheckboxState = envVars[airIndoorsKey]
+      ? envVars[airIndoorsKey]
       : '0';
   }
   return currentCheckboxState;
@@ -139,44 +177,83 @@ function determineCurrentCheckboxState(
 
 function formatAirSamplingInterval(
   formData: FormData,
-  envVars: { [x: string]: string }
+  envVars: { [x: string]: string },
+  productUID: string
 ) {
+  const isV3 = productUID === AIRNOTE_V3_PRODUCT_UID;
+  const airMinsKey = isV3 ? 'air_mins' : '_air_mins';
+
   if (formData.get('sampleFrequencyFull')) {
     return `usb:15;high:${formData.get(
       'sampleFrequencyFull'
     )};normal:${formData.get('sampleFrequencyFull')};low:720;43200`;
   } else {
-    return envVars['_air_mins'];
+    return envVars[airMinsKey];
   }
 }
 
 function createEnvVarBody(
   formData: FormData,
-  envVars: { [x: string]: string }
+  envVars: { [x: string]: string },
+  productUID: string
 ) {
   // combine existing Airnote env vars with the new form data for accurate env var bdy request
-  const currentCheckboxState = determineCurrentCheckboxState(formData, envVars);
+  const isV3 = productUID === AIRNOTE_V3_PRODUCT_UID;
+  const currentCheckboxState = determineCurrentCheckboxState(
+    formData,
+    envVars,
+    productUID
+  );
 
-  return {
-    _sn: formData.has('deviceName')
-      ? formData.get('deviceName')
-      : envVars['_sn'],
-    _air_mins: formatAirSamplingInterval(formData, envVars),
-    _air_indoors: currentCheckboxState,
-    _air_status: formData.get('displayValue')
-      ? formData.get('displayValue')
-      : envVars['_air_status'],
-    _contact_name: formData.has('contactName')
-      ? formData.get('contactName')
-      : envVars['_contact_name'],
-    _contact_email: formData.has('contactEmail')
-      ? formData.get('contactEmail')
-      : envVars['_contact_email'],
-    _contact_affiliation: formData.has('contactAffiliation')
-      ? formData.get('contactAffiliation')
-      : envVars['_contact_affiliation'],
-    _route: formData.has('routingUrl')
-      ? formData.get('routingUrl')
-      : envVars['_route']
-  };
+  console.log('createEnvVarBody - Is v3:', isV3, 'productUID:', productUID);
+
+  // For v3 devices, use env vars without underscores. For legacy devices, use with underscores.
+  // todo refactor to reduce redundancy
+  if (isV3) {
+    return {
+      _sn: formData.has('deviceName')
+        ? formData.get('deviceName')
+        : envVars['_sn'],
+      air_mins: formatAirSamplingInterval(formData, envVars, productUID),
+      air_indoors: currentCheckboxState,
+      air_status: formData.get('displayValue')
+        ? formData.get('displayValue')
+        : envVars['air_status'],
+      _contact_name: formData.has('contactName')
+        ? formData.get('contactName')
+        : envVars['_contact_name'],
+      _contact_email: formData.has('contactEmail')
+        ? formData.get('contactEmail')
+        : envVars['_contact_email'],
+      _contact_affiliation: formData.has('contactAffiliation')
+        ? formData.get('contactAffiliation')
+        : envVars['_contact_affiliation'],
+      _route: formData.has('routingUrl')
+        ? formData.get('routingUrl')
+        : envVars['_route']
+    };
+  } else {
+    return {
+      _sn: formData.has('deviceName')
+        ? formData.get('deviceName')
+        : envVars['_sn'],
+      _air_mins: formatAirSamplingInterval(formData, envVars, productUID),
+      _air_indoors: currentCheckboxState,
+      _air_status: formData.get('displayValue')
+        ? formData.get('displayValue')
+        : envVars['_air_status'],
+      _contact_name: formData.has('contactName')
+        ? formData.get('contactName')
+        : envVars['_contact_name'],
+      _contact_email: formData.has('contactEmail')
+        ? formData.get('contactEmail')
+        : envVars['_contact_email'],
+      _contact_affiliation: formData.has('contactAffiliation')
+        ? formData.get('contactAffiliation')
+        : envVars['_contact_affiliation'],
+      _route: formData.has('routingUrl')
+        ? formData.get('routingUrl')
+        : envVars['_route']
+    };
+  }
 }

--- a/src/routes/[deviceUID]/+page.svelte
+++ b/src/routes/[deviceUID]/+page.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
   import { NotificationDisplay, notifier } from '@beyonk/svelte-notifications';
-  import { APP_UID, RADNOTE_PRODUCT_UID } from '$lib/constants';
+  import {
+    APP_UID,
+    AIRNOTE_V3_PRODUCT_UID,
+    RADNOTE_PRODUCT_UID
+  } from '$lib/constants';
   import { getCurrentDeviceFromUrl } from '$lib/services/device';
   import DeviceSettings from './DeviceSettings.svelte';
   import DeviceOwner from './DeviceOwner.svelte';
@@ -22,6 +28,7 @@
     AirnoteDevice,
     PotentiallyNullDeviceDetails
   } from '$lib/services/DeviceModel';
+  import type { DeviceDisplayOption } from '$lib/services/DeviceDisplayModel';
   import { ERROR_TYPE } from '$lib/constants/ErrorTypes';
   import { renderErrorMessage } from '$lib/util/errors';
   import { getNotehubEventsUrl } from '$lib/util/url';
@@ -40,37 +47,81 @@
     eventsUrl = getNotehubEventsUrl(deviceUID);
   }
 
-  const deviceDisplayOptions = [
-    { value: 'tempc', text: 'Temp (°C)' },
-    { value: 'tempf', text: 'Temp (°F)' },
-    { value: 'humid', text: 'Humidity' },
-    { value: 'press', text: 'Barometric Pressure' }
-  ];
+  export let data;
 
-  if (productUID === RADNOTE_PRODUCT_UID) {
-    displayValue.set('usv');
+  // Use productUID from server data if available
+  $: if (data.productUID) {
+    productUID = data.productUID;
 
-    deviceDisplayOptions.splice(0, 0, {
-      value: 'usv',
-      text: 'Microsieverts per Hour (default)'
-    });
-    deviceDisplayOptions.push({ value: 'mrem', text: 'Milirem per Hour' });
-    deviceDisplayOptions.push({
-      value: 'cpm',
-      text: 'LND712 Counts Per Minute'
-    });
-  } else {
-    displayValue.set('pm2.5');
-
-    deviceDisplayOptions.splice(0, 0, {
-      value: 'pm2.5',
-      text: 'PM2.5 (default)'
-    });
-    deviceDisplayOptions.push({ value: 'pm1.0', text: 'PM1.0' });
-    deviceDisplayOptions.push({ value: 'pm10.0', text: 'PM10.0' });
+    // Update the URL to reflect the correct productUID while preserving other params
+    const currentProductInUrl = $page.url.searchParams.get('product');
+    if (currentProductInUrl !== productUID) {
+      const newUrl = new URL($page.url);
+      // This preserves all existing query params (pin, internalNav, etc.) and only updates product
+      newUrl.searchParams.set('product', productUID);
+      goto(newUrl.toString(), {
+        replaceState: true,
+        noScroll: true,
+        keepFocus: true
+      });
+    }
   }
 
-  export let data;
+  // Make deviceDisplayOptions reactive to productUID changes
+  let deviceDisplayOptions: DeviceDisplayOption[] = [];
+  let hasSetDefaultDisplayValue = false;
+
+  $: {
+    // Reset the options array
+    deviceDisplayOptions = [
+      { value: 'tempc', text: 'Temp (°C)' },
+      { value: 'tempf', text: 'Temp (°F)' },
+      { value: 'humid', text: 'Humidity' },
+      { value: 'press', text: 'Barometric Pressure' }
+    ];
+
+    // Set default display value and add product-specific options
+    // Only set default if we haven't already set it (to avoid overriding saved settings)
+    if (productUID === RADNOTE_PRODUCT_UID) {
+      if (!hasSetDefaultDisplayValue) {
+        displayValue.set('usv');
+        hasSetDefaultDisplayValue = true;
+      }
+      deviceDisplayOptions.splice(0, 0, {
+        value: 'usv',
+        text: 'Microsieverts per Hour (default)'
+      });
+      deviceDisplayOptions.push({ value: 'mrem', text: 'Milirem per Hour' });
+      deviceDisplayOptions.push({
+        value: 'cpm',
+        text: 'LND712 Counts Per Minute'
+      });
+    } else if (productUID === AIRNOTE_V3_PRODUCT_UID) {
+      if (!hasSetDefaultDisplayValue) {
+        displayValue.set('aqi');
+        hasSetDefaultDisplayValue = true;
+      }
+      deviceDisplayOptions.splice(0, 0, {
+        value: 'aqi',
+        text: 'AQI (default)'
+      });
+      deviceDisplayOptions.push({ value: 'pm2.5', text: 'PM2.5' });
+      deviceDisplayOptions.push({ value: 'pm1.0', text: 'PM1.0' });
+      deviceDisplayOptions.push({ value: 'pm10.0', text: 'PM10.0' });
+    } else if (productUID) {
+      // Default airnote
+      if (!hasSetDefaultDisplayValue) {
+        displayValue.set('pm2.5');
+        hasSetDefaultDisplayValue = true;
+      }
+      deviceDisplayOptions.splice(0, 0, {
+        value: 'pm2.5',
+        text: 'PM2.5 (default)'
+      });
+      deviceDisplayOptions.push({ value: 'pm1.0', text: 'PM1.0' });
+      deviceDisplayOptions.push({ value: 'pm10.0', text: 'PM10.0' });
+    }
+  }
 
   if (data.error !== undefined) {
     if (data.error.errorType === ERROR_TYPE.MISSING_PIN) {
@@ -89,14 +140,27 @@
     enableFields = true;
   }
 
-  const updateSettingsFromEnvVars = (data: { [property: string]: string }) => {
+  const updateSettingsFromEnvVars = (
+    data: { [property: string]: string },
+    currentProductUID: string
+  ) => {
     if (data['_sn']) deviceName.set(data['_sn']);
-    if (data['_air_mins']) {
+
+    // For v3 devices, only use non-underscore vars. For legacy devices, use underscore vars.
+    const isV3 = currentProductUID === AIRNOTE_V3_PRODUCT_UID;
+
+    const airMinsVar = isV3
+      ? data['air_mins']
+      : data['_air_mins'] || data['air_mins'];
+    const airIndoorsVar = isV3
+      ? data['air_indoors']
+      : data['_air_indoors'] || data['air_indoors'];
+    const airStatusVar = isV3 ? data['air_status'] : data['_air_status'];
+
+    if (airMinsVar) {
       // Split semi-colon list into an array for parsing and reassembly
       // "usb:15;high:123;normal:123;low:720;0"
-      const airMinsVals = data['_air_mins']
-        .split(';')
-        .map((item) => item.split(':'));
+      const airMinsVals = airMinsVar.split(';').map((item) => item.split(':'));
       for (let index = 0; index < airMinsVals.length; index++) {
         const element = airMinsVals[index];
         switch (element[0]) {
@@ -112,9 +176,11 @@
         }
       }
     }
-    if (data['_air_indoors'])
-      indoorDevice.set(data['_air_indoors'] === '0' ? false : true);
-    if (data['_air_status']) displayValue.set(data['_air_status']);
+    if (airIndoorsVar) indoorDevice.set(airIndoorsVar === '0' ? false : true);
+    if (airStatusVar) {
+      displayValue.set(airStatusVar);
+      hasSetDefaultDisplayValue = true; // Mark that we've loaded a saved value
+    }
     if (data['_contact_name']) contactName.set(data['_contact_name']);
     if (data['_contact_email']) contactEmail.set(data['_contact_email']);
     if (data['_contact_affiliation'])
@@ -122,8 +188,9 @@
     if (data['_route']) routingUrl.set(data['_route']);
   };
 
-  if (data.notehubResponse) {
-    updateSettingsFromEnvVars(data.notehubResponse);
+  // Reactively update settings when both notehubResponse and productUID are available
+  $: if (data.notehubResponse && productUID) {
+    updateSettingsFromEnvVars(data.notehubResponse, productUID);
   }
 
   const handleSettingsSaved = () => {
@@ -142,7 +209,7 @@
     internalNav = currentDevice.internalNav
       ? currentDevice.internalNav
       : 'false';
-    productUID = currentDevice.productUID ? currentDevice.productUID : '';
+    // productUID now comes from server data, don't override it from URL
   });
 </script>
 

--- a/src/routes/[deviceUID]/+page.svelte
+++ b/src/routes/[deviceUID]/+page.svelte
@@ -55,7 +55,7 @@
 
     // Update the URL to reflect the correct productUID while preserving other params
     const currentProductInUrl = $page.url.searchParams.get('product');
-    if (currentProductInUrl !== productUID) {
+    if (typeof productUID === 'string' && currentProductInUrl !== productUID) {
       const newUrl = new URL($page.url);
       // This preserves all existing query params (pin, internalNav, etc.) and only updates product
       newUrl.searchParams.set('product', productUID);
@@ -82,45 +82,51 @@
 
     // Set default display value and add product-specific options
     // Only set default if we haven't already set it (to avoid overriding saved settings)
-    if (productUID === RADNOTE_PRODUCT_UID) {
-      if (!hasSetDefaultDisplayValue) {
-        displayValue.set('usv');
-        hasSetDefaultDisplayValue = true;
+    const productConfig: Record<string, {
+      defaultValue: string;
+      defaultOption: { value: string; text: string };
+      additionalOptions: { value: string; text: string }[];
+    }> = {
+      [RADNOTE_PRODUCT_UID]: {
+        defaultValue: 'usv',
+        defaultOption: { value: 'usv', text: 'Microsieverts per Hour (default)' },
+        additionalOptions: [
+          { value: 'mrem', text: 'Milirem per Hour' },
+          { value: 'cpm', text: 'LND712 Counts Per Minute' }
+        ]
+      },
+      [AIRNOTE_V3_PRODUCT_UID]: {
+        defaultValue: 'aqi',
+        defaultOption: { value: 'aqi', text: 'AQI (default)' },
+        additionalOptions: [
+          { value: 'pm2.5', text: 'PM2.5' },
+          { value: 'pm1.0', text: 'PM1.0' },
+          { value: 'pm10.0', text: 'PM10.0' }
+        ]
       }
-      deviceDisplayOptions.splice(0, 0, {
-        value: 'usv',
-        text: 'Microsieverts per Hour (default)'
-      });
-      deviceDisplayOptions.push({ value: 'mrem', text: 'Milirem per Hour' });
-      deviceDisplayOptions.push({
-        value: 'cpm',
-        text: 'LND712 Counts Per Minute'
-      });
-    } else if (productUID === AIRNOTE_V3_PRODUCT_UID) {
-      if (!hasSetDefaultDisplayValue) {
-        displayValue.set('aqi');
-        hasSetDefaultDisplayValue = true;
-      }
-      deviceDisplayOptions.splice(0, 0, {
-        value: 'aqi',
-        text: 'AQI (default)'
-      });
-      deviceDisplayOptions.push({ value: 'pm2.5', text: 'PM2.5' });
-      deviceDisplayOptions.push({ value: 'pm1.0', text: 'PM1.0' });
-      deviceDisplayOptions.push({ value: 'pm10.0', text: 'PM10.0' });
-    } else if (productUID) {
-      // Default airnote
-      if (!hasSetDefaultDisplayValue) {
-        displayValue.set('pm2.5');
-        hasSetDefaultDisplayValue = true;
-      }
-      deviceDisplayOptions.splice(0, 0, {
-        value: 'pm2.5',
-        text: 'PM2.5 (default)'
-      });
-      deviceDisplayOptions.push({ value: 'pm1.0', text: 'PM1.0' });
-      deviceDisplayOptions.push({ value: 'pm10.0', text: 'PM10.0' });
+    };
+
+    // Default config for legacy Airnote
+    const defaultConfig = {
+      defaultValue: 'pm2.5',
+      defaultOption: { value: 'pm2.5', text: 'PM2.5 (default)' },
+      additionalOptions: [
+        { value: 'pm1.0', text: 'PM1.0' },
+        { value: 'pm10.0', text: 'PM10.0' }
+      ]
+    };
+
+    const config = typeof productUID === 'string' && productConfig[productUID]
+      ? productConfig[productUID]
+      : defaultConfig;
+
+    if (!hasSetDefaultDisplayValue) {
+      displayValue.set(config.defaultValue);
+      hasSetDefaultDisplayValue = true;
     }
+
+    deviceDisplayOptions.splice(0, 0, config.defaultOption);
+    deviceDisplayOptions.push(...config.additionalOptions);
   }
 
   if (data.error !== undefined) {
@@ -189,7 +195,7 @@
   };
 
   // Reactively update settings when both notehubResponse and productUID are available
-  $: if (data.notehubResponse && productUID) {
+  $: if (data.notehubResponse && typeof productUID === 'string') {
     updateSettingsFromEnvVars(data.notehubResponse, productUID);
   }
 


### PR DESCRIPTION
# Problem Context

A new `aqi` value is being calculated on the v3 Airnotes, so we need to display (and default to) AQI on the settings page when it's a v3 Airnote being viewed.

The new Airnotes can be found via the product UIDs beginning with `com.blues.airnote.v3` and in addition to the extra setting in the dropdown, consider changing the title of that section also to indicate it’s a v3 Airnote a user is looking at. 

Additionally, the env vars that control Airnote settings like `_air_mins` or `_air_status` or `_air_indoors` have been updated for v3 to `air_mins`, `air_status`, and `air_indoors`, so that needs to be accounted for when updating the settings from the dashboard.

## Changes

* Add new Airnote v3 product UID to constants
* Update DeviceEnvVars model to include Airnote v3 env vars (`air_mins`, `air_indoors`, and `air_status`)
* Update Notehub.ts file to fetch Airnote device info and make it flexible enough to handle both Airnote v1 & Airnote v3 environment variable update requests
* Update the Settings page `+page.server.ts` file to determine which product UID is being viewed by fetching data from the Notehub API (because now it affects the request to update env vars across different devices)
* Update the Settings page `+page.svelte` file to fetch the product UID from the Notehub API and update its URL appropriately while preserving all other existing query params, and displaying the correct options in the dropdown based on which product UID is currently being viewed

## Screenshot (if applicable)

Default 
<img width="1136" height="1304" alt="Screenshot 2025-12-22 at 2 49 09 PM" src="https://github.com/user-attachments/assets/95e6434d-798b-42f0-8965-c2d9c0ba1567" />
AQI setting for v3 Airnote (as determined by URL)

Assigned user setting for v1 Airnote (as determined by URL and fetching env vars from Notehub for this device)
<img width="1136" height="1007" alt="Screenshot 2025-12-22 at 2 49 35 PM" src="https://github.com/user-attachments/assets/30f9a7ff-8691-49c0-bc5d-636a4908afa6" />

## Testing

Unit / integration / e2e tests?

All tests pass

Steps to test manually?

1. After starting the app, go to a v3 Airnote like this one: http://localhost:5173/dev:868531060199234
2. Navigate to the Settings page and see that the URL in the browser automatically detects it's a v3 Airnote and updates accordingly and the default setting for the dropdown is set to AQI
3. To verify these env vars are correctly being displayed from Notehub, you can go visit that device's settings here: https://notehub.io/project/app:2606f411-dea6-44a0-9743-1130f57d77d8/devices/dev:868531060199234/environment/basic
4. Now replace the URL with a v1 Airnote like this one: http://localhost:5173/dev:864475044215258
5. Navigate again to the Settings page and see the URL in the browser display's it's not a v3 Airnote

Any other sorts of testing notes to include?

## Any other related PRs

n/a

## Ticket(s)

https://bluesinc.atlassian.net/jira/software/c/projects/BLUESDEV/boards/13?selectedIssue=BLUESDEV-500
