### PR TITLE
feat: adding a badge to dashboard for indoor devices

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,96 @@
+# CLAUDE.md
+
+## Project Overview
+
+Airnote.live is a web app for configuring and monitoring Blues Airnote air quality devices. Users scan a QR code on their device to change device settings, and view real-time AQI, PM2.5, temperature, humidity, and voltage readings, plus historical charts and a map. Built as an open-source reference for Notecard-based web apps.
+
+Live at https://airnote.live
+
+## Tech Stack
+
+- **Framework:** SvelteKit 2 with Svelte 4
+- **Language:** TypeScript (strict mode)
+- **Build:** Vite 5
+- **Deployment:** Netlify (adapter-netlify)
+- **Node:** 20.17.0 (Volta)
+- **Charts:** Chart.js 4 with date-fns adapter
+- **Maps:** Mapbox GL
+- **API Client:** @blues-inc/notehub-js
+- **Markdown:** MDSvex with remark/rehype plugins
+
+## Commands
+
+```bash
+npm run dev          # Dev server (localhost:5173)
+npm run build        # Production build
+npm run preview      # Preview production build
+npm run check        # Type check (svelte-check)
+npm run test         # Unit tests (Vitest)
+npm run lint         # Prettier + ESLint check
+npm run format       # Auto-format with Prettier
+npm run cypress:open # E2E tests (interactive)
+npm run cypress:run  # E2E tests (headless)
+```
+
+## Project Structure
+
+```
+src/
+├── lib/
+│   ├── components/       # UI components
+│   │   └── charts/       # AQI, PM, Temperature, Humidity, Voltage charts
+│   ├── constants/        # Enums and constants (DateRangeOptions, ErrorTypes, TooltipStates)
+│   ├── constants.ts      # Global constants (product UIDs, API URL, GA ID)
+│   ├── icons/            # SVG icon components
+│   ├── images/           # Static images
+│   ├── layout/           # Header, Footer
+│   ├── services/         # Business logic & API layer
+│   │   ├── notehub.ts    # Notehub API wrapper
+│   │   ├── device.ts     # Device data processing
+│   │   ├── air.ts        # AQI calculations, heat index
+│   │   └── *Model.ts     # TypeScript interfaces
+│   ├── stores/           # Svelte writable stores (settings state)
+│   └── util/             # Helpers (dates, errors, share, url)
+├── routes/
+│   ├── +page.svelte              # Home (device UID entry)
+│   ├── [deviceUID]/
+│   │   ├── +page.server.ts       # Device settings loader
+│   │   ├── +page.svelte          # Device settings page
+│   │   └── dashboard/
+│   │       ├── +page.server.ts   # Dashboard data loader
+│   │       └── +page.svelte      # Dashboard with charts/map
+│   ├── quickstart/               # Setup guide (MDSvex)
+│   └── api/download/+server.ts   # CSV export endpoint
+└── test/
+    └── services/device.test.ts   # Unit tests
+```
+
+## Environment Variables
+
+Required in `.env`:
+- `HUB_AUTH_TOKEN` — Notehub API token (server-side)
+- `PUBLIC_MAPBOX_TOKEN` — Mapbox access token (client-side, must be `PUBLIC_` prefixed)
+
+## Code Conventions
+
+- **Formatting:** Prettier — 2 spaces, single quotes, no trailing commas, 80 char width
+- **Components:** PascalCase `.svelte` files
+- **Services/utils:** camelCase `.ts` files
+- **Models:** Separate `*Model.ts` files with TypeScript interfaces
+- **Data fetching:** Server-side in `+page.server.ts` via `load()` functions
+- **State:** Svelte writable stores for form state; SvelteKit page stores for URL params
+- **Testing:** `data-cy="..."` attributes for Cypress selectors
+- **Imports:** Use `$lib/` alias for anything under `src/lib/`
+
+## Key Patterns
+
+- Device data flows: Notehub API → `notehub.ts` → `device.ts` (processing) → `+page.server.ts` (load) → components
+- PIN-based authentication for device settings changes
+- Charts are reactive Svelte components wrapping Chart.js canvases
+- CSV export via `/api/download` server endpoint using PapaParse
+
+## Deployment
+
+Netlify auto-deploys from git. Config in `netlify.toml`:
+- Build: `npm run build`
+- Publish: `build/`

--- a/src/routes/[deviceUID]/+page.server.ts
+++ b/src/routes/[deviceUID]/+page.server.ts
@@ -163,7 +163,7 @@ function determineCurrentCheckboxState(
 
   // required logic because unchecked checkboxes are not included in the form data
   // figure out if device settings form is being submitted
-  if (formData.get('deviceName')) {
+  if (formData.has('deviceName')) {
     // check if checkbox data is included in form body (it means checkbox is checked)
     if (formData.get('indoorDevice') === 'on') {
       currentCheckboxState = '1';

--- a/src/routes/[deviceUID]/dashboard/+page.server.ts
+++ b/src/routes/[deviceUID]/dashboard/+page.server.ts
@@ -14,6 +14,7 @@ export async function load({ params }) {
   const deviceUID = params.deviceUID;
   const allEvents: NotehubEvent[] = [];
   let readings: AirnoteReading[] = [];
+  let isIndoor = false;
   let history: AirnoteHistoryReadings = {
     aqi: {},
     pm1_0: {},
@@ -38,7 +39,10 @@ export async function load({ params }) {
   ])
     .then((responses) => {
       const [envVarResponse, eventsResponse] = responses;
-      const serialNumber = envVarResponse.environment_variables._sn;
+      const envVars = envVarResponse.environment_variables;
+      const serialNumber = envVars._sn;
+      isIndoor =
+        envVars._air_indoors === '1' || envVars.air_indoors === '1';
       allEvents.push(...eventsResponse.events);
       allEvents.forEach((entry) => (entry.serial_number = serialNumber));
       readings = getCurrentReadings(allEvents, deviceUID);
@@ -51,25 +55,23 @@ export async function load({ params }) {
     });
 
   if (erred) {
-    if (notehubError) {
-      if (notehubError.status === 404) {
-        error(404, {
-          message: 'Device not found',
-          errorType: ERROR_TYPE.NOTEHUB_ERROR,
-          deviceUID
-        });
-      } else {
-        error(500, {
-          message: 'Error fetching data from Notehub',
-          errorType: ERROR_TYPE.NOTEHUB_ERROR,
-          deviceUID
-        });
-      }
+    if (notehubError && notehubError.status === 404) {
+      error(404, {
+        message: 'Device not found',
+        errorType: ERROR_TYPE.NOTEHUB_ERROR,
+        deviceUID
+      });
     }
-  } else {
-    return {
-      readings,
-      history
-    };
+    error(500, {
+      message: 'Error fetching data from Notehub',
+      errorType: ERROR_TYPE.NOTEHUB_ERROR,
+      deviceUID
+    });
   }
+
+  return {
+    readings,
+    history,
+    isIndoor
+  };
 }

--- a/src/routes/[deviceUID]/dashboard/+page.svelte
+++ b/src/routes/[deviceUID]/dashboard/+page.svelte
@@ -66,12 +66,18 @@
   // data fetched from Notehub API via +page.server.ts on page load
   export let data;
 
+  let isIndoor = false;
+
   if (data && data.readings) {
     readings = data.readings;
   }
 
   if (data && data.history) {
     history = data.history;
+  }
+
+  if (data && data.isIndoor) {
+    isIndoor = data.isIndoor;
   }
 
   if (!readings || readings.length === 0) {
@@ -158,7 +164,7 @@
       </span>
     </h2>
 
-    <Actions {deviceUID} />
+    <Actions {deviceUID} {isIndoor} />
 
     <div class="all-measurements box">
       <h3 class="current-readings-title">Current Reading</h3>

--- a/src/routes/[deviceUID]/dashboard/Actions.svelte
+++ b/src/routes/[deviceUID]/dashboard/Actions.svelte
@@ -5,9 +5,19 @@
   import { shareDashboard } from '$lib/util/share';
 
   export let deviceUID: string;
+  export let isIndoor: boolean = false;
 </script>
 
 <div class="actions">
+  {#if isIndoor}
+    <div
+      class="indoor-badge"
+      title="This device is marked as an indoor device. You can change this designation in the device's settings."
+    >
+      Indoor Device
+    </div>
+  {/if}
+  <div class="action-buttons">
   <a rel="external" href={`/api/download?deviceUID=${deviceUID}`}>
     <button>
       <DownloadIcon />
@@ -24,13 +34,27 @@
     <ShareIcon />
     <span>Share</span>
   </button>
+  </div>
 </div>
 
 <style>
   .actions {
     display: flex;
-    justify-content: flex-end;
+    justify-content: space-between;
+    align-items: center;
+  }
+  .indoor-badge {
+    background: var(--bannerBlue);
+    color: var(--notehubBlue);
+    font-size: 0.8rem;
+    font-weight: 600;
+    padding: 0.25rem 0.75rem;
+    border-radius: 1rem;
+  }
+  .action-buttons {
+    display: flex;
     gap: 1.5rem;
+    margin-left: auto;
   }
   .actions button {
     background: transparent;


### PR DESCRIPTION
This PR adds a small little badge to the top of the screen of devices marked as indoor. If the user hovers over the badge they’ll get a message that `This device is marked as an indoor device. You can change this designation in the device's settings.` Here’s what it looks like.

<img width="1214" height="766" alt="Screenshot 2026-02-17 at 1 30 08 PM" src="https://github.com/user-attachments/assets/2e06e9f3-c3fd-4742-9a8d-0d7f21eb5681" />

I also fixed a small bug that wouldn't let you change whether a device was indoors or not if the device did not have a name `_sn`.